### PR TITLE
Better error handling for load

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,16 @@
+module.exports = {
+  ERROR_LOAD_FILE_OUTSIDE_BROWSER: `
+    Direct raster loading is currently not supported outside of the browser
+    due to dependency limitations. Please use either a url or run the code
+    in the browser.
+  `,
+  ERROR_BAD_URL: `
+    Geoblaze could not load the file. This is usually because the url is incorrect
+    or the website's security prevents cross domain requests. Try again or download
+    the file and load it manually.
+  `,
+  ERROR_PARSING_GEOTIFF: `
+    Geoblaze had a problem parsing this file. Please make sure that you are sending a proper
+    GeoTIFF file and try again.
+  `
+};

--- a/env.js
+++ b/env.js
@@ -1,5 +1,5 @@
 const debug_level = process.env.DEBUG_LEVEL || 0;
 
 module.exports = {
-    debug_level
+  debug_level
 };

--- a/index.js
+++ b/index.js
@@ -1,27 +1,27 @@
 'use strict';
 
 var geoblaze = {
-	cache: require('./packages/cache/cache'),
-	load: require('./packages/load/load'),
-	identify: require('./packages/identify/identify'),
-	sum: require('./packages/sum/sum'),
-	mean: require('./packages/mean/mean'),
-	median: require('./packages/median/median'),
-	min: require('./packages/min/min'),
-	max: require('./packages/max/max'),
-	mode: require('./packages/mode/mode'),
-    histogram: require('./packages/histogram/histogram')
+  cache: require('./packages/cache/cache'),
+  load: require('./packages/load/load'),
+  identify: require('./packages/identify/identify'),
+  sum: require('./packages/sum/sum'),
+  mean: require('./packages/mean/mean'),
+  median: require('./packages/median/median'),
+  min: require('./packages/min/min'),
+  max: require('./packages/max/max'),
+  mode: require('./packages/mode/mode'),
+  histogram: require('./packages/histogram/histogram')
 };
 
 if (typeof module !== "undefined" && typeof module.exports !== "undefined") {
-    module.exports = geoblaze;
+  module.exports = geoblaze;
 }
 
 /*
-    The following code allows you to use GeoRaster without requiring
+  The following code allows you to use GeoRaster without requiring
 */
 if (typeof window !== "undefined") {
-    window["geoblaze"] = geoblaze;
+  window["geoblaze"] = geoblaze;
 } else if (typeof self !== "undefined") {
-    self["geoblaze"] = geoblaze; // jshint ignore:line
+  self["geoblaze"] = geoblaze; // jshint ignore:line
 }

--- a/logger.js
+++ b/logger.js
@@ -6,31 +6,31 @@ const debug_level = require('./env').debug_level;
 // first statement is run
 
 function run_or_log_statements(format, ...statements) {
-    const first_statement = statements[0];
-    if (typeof first_statement === 'function') {
-        first_statement();
-    } else {
-        console[format](statements);
-    }
+  const first_statement = statements[0];
+  if (typeof first_statement === 'function') {
+    first_statement();
+  } else {
+    console[format](statements);
+  }
 }
 
 module.exports = {
 
-    debug(...statements) {
-        if (debug_level >= 2) {
-            run_or_log_statements('log', ...statements);
-        }
-    },
-
-    info(...statements) {
-        if (debug_level) {
-            run_or_log_statements('log', ...statements);
-        }
-    },
-
-    error(...statements) {
-        if (debug_level) {
-            run_or_log_statements('error', ...statements);
-        }
+  debug(...statements) {
+    if (debug_level >= 2) {
+      run_or_log_statements('log', ...statements);
     }
+  },
+
+  info(...statements) {
+    if (debug_level) {
+      run_or_log_statements('log', ...statements);
+    }
+  },
+
+  error(...statements) {
+    if (debug_level) {
+      run_or_log_statements('error', ...statements);
+    }
+  }
 }

--- a/packages/cache/cache.js
+++ b/packages/cache/cache.js
@@ -1,3 +1,3 @@
 module.exports = {
-    
+
 }

--- a/packages/convert-geometry/convert-geometry.js
+++ b/packages/convert-geometry/convert-geometry.js
@@ -7,94 +7,94 @@ let utils = require('../utils/utils');
 // let turf = require('@turf/turf');
 
 let convert_point = geometry => {
-    let point;
-    if (Array.isArray(geometry) && geometry.length === 2) { // array
-        point = geometry;
-    } else if (typeof geometry === 'string') { // stringified geojson
-        let geojson = JSON.parse(geometry);
-        if (geojson.type === 'Point') {
-            point = geojson.coordinates;
-        }
-    } else if (typeof geometry === 'object') { // geojson
-        if (geometry.type === 'Point') {
-            point = geometry.coordinates;
-        }
+  let point;
+  if (Array.isArray(geometry) && geometry.length === 2) { // array
+    point = geometry;
+  } else if (typeof geometry === 'string') { // stringified geojson
+    let geojson = JSON.parse(geometry);
+    if (geojson.type === 'Point') {
+      point = geojson.coordinates;
     }
-
-    if (!point) {
-        throw `Invalid point object was used.
-            Please use either a [lng, lat] array or GeoJSON point.`;
+  } else if (typeof geometry === 'object') { // geojson
+    if (geometry.type === 'Point') {
+      point = geometry.coordinates;
     }
+  }
 
-    return point;
+  if (!point) {
+    throw `Invalid point object was used.
+      Please use either a [lng, lat] array or GeoJSON point.`;
+  }
+
+  return point;
 }
 
 let convert_bbox = geometry => {
-    let bbox;
-    if (utils.is_bbox(geometry)) {
-        if (typeof geometry.xmin !== "undefined" && typeof geometry.ymax !== "undefined") {
-            bbox = geometry;
-        }
-        else if (Array.isArray(geometry) && geometry.length === 4) { // array
-            bbox = { xmin: geometry[0], ymin: geometry[1], xmax: geometry[2], ymax: geometry[3] };
-        } else if (typeof geometry === 'string') { // stringified geojson
-            let geojson = JSON.parse(geometry);
-            let coors = utils.get_geojson_coors(geojson)[0];
-            let lngs = coors.map(coor => coor[0]);
-            let lats = coors.map(coor => coor[1]);
-            bbox = { xmin: Math.min(...lngs), ymin: Math.min(...lats), xmax: Math.max(...lngs), ymax: Math.max(...lats) };
-        } else if (typeof geometry === 'object') { // geojson
-            let coors = utils.get_geojson_coors(geometry)[0];
-            let lngs = coors.map(coor => coor[0]);
-            let lats = coors.map(coor => coor[1]);
-            bbox = { xmin: Math.min(...lngs), ymin: Math.min(...lats), xmax: Math.max(...lngs), ymax: Math.max(...lats) };
-        }
+  let bbox;
+  if (utils.is_bbox(geometry)) {
+    if (typeof geometry.xmin !== "undefined" && typeof geometry.ymax !== "undefined") {
+      bbox = geometry;
     }
-        
-    if (!bbox) {
-        throw `Invalid bounding box object was used. 
-            Please use either a [xmin, ymin, xmax, ymax] array or GeoJSON polygon.`
+    else if (Array.isArray(geometry) && geometry.length === 4) { // array
+      bbox = { xmin: geometry[0], ymin: geometry[1], xmax: geometry[2], ymax: geometry[3] };
+    } else if (typeof geometry === 'string') { // stringified geojson
+      let geojson = JSON.parse(geometry);
+      let coors = utils.get_geojson_coors(geojson)[0];
+      let lngs = coors.map(coor => coor[0]);
+      let lats = coors.map(coor => coor[1]);
+      bbox = { xmin: Math.min(...lngs), ymin: Math.min(...lats), xmax: Math.max(...lngs), ymax: Math.max(...lats) };
+    } else if (typeof geometry === 'object') { // geojson
+      let coors = utils.get_geojson_coors(geometry)[0];
+      let lngs = coors.map(coor => coor[0]);
+      let lats = coors.map(coor => coor[1]);
+      bbox = { xmin: Math.min(...lngs), ymin: Math.min(...lats), xmax: Math.max(...lngs), ymax: Math.max(...lats) };
     }
+  }
 
-    return bbox;
+  if (!bbox) {
+    throw `Invalid bounding box object was used.
+      Please use either a [xmin, ymin, xmax, ymax] array or GeoJSON polygon.`
+  }
+
+  return bbox;
 }
 
 let convert_polygon = geometry => {
-    let polygon;
-    if (utils.is_polygon(geometry)) {
-        if (Array.isArray(geometry)) { // array
-            polygon = geometry;
-        } else if (typeof geometry === 'string') { // stringified geojson
-            let parsed = JSON.parse(geometry);
-            let geojson = utils.convert_to_geojson_if_necessary(parsed);
-            polygon = utils.get_geojson_coors(geojson);
-        } else if (typeof geometry === 'object') { // geojson
-            let geojson = utils.convert_to_geojson_if_necessary(geometry);
-            polygon = utils.get_geojson_coors(geojson);
-        }
+  let polygon;
+  if (utils.is_polygon(geometry)) {
+    if (Array.isArray(geometry)) { // array
+      polygon = geometry;
+    } else if (typeof geometry === 'string') { // stringified geojson
+      let parsed = JSON.parse(geometry);
+      let geojson = utils.convert_to_geojson_if_necessary(parsed);
+      polygon = utils.get_geojson_coors(geojson);
+    } else if (typeof geometry === 'object') { // geojson
+      let geojson = utils.convert_to_geojson_if_necessary(geometry);
+      polygon = utils.get_geojson_coors(geojson);
     }
+  }
 
-    if (!polygon) {
-        throw `Invalild polygon object was used.
-            Please use either a [[[x00,y00],...,[x0n,y0n],[x00,y00]]...] array or GeoJSON polygon.`
-    }
+  if (!polygon) {
+    throw `Invalild polygon object was used.
+      Please use either a [[[x00,y00],...,[x0n,y0n],[x00,y00]]...] array or GeoJSON polygon.`
+  }
 
-    return polygon;
+  return polygon;
 }
 
 module.exports = (type_of_geometry, geometry) => {
-    try {
-        if (type_of_geometry === 'point') {
-            return convert_point(geometry);
-        } else if (type_of_geometry === 'bbox') {
-            return convert_bbox(geometry);
-        } else if (type_of_geometry === 'polygon') {
-            return convert_polygon(geometry);
-        } else {
-            throw 'Invalid geometry type was specified. Please use either "point" or "polygon"';
-        }
-    } catch(e) {
-        console.error(e);
-        throw e;
+  try {
+    if (type_of_geometry === 'point') {
+      return convert_point(geometry);
+    } else if (type_of_geometry === 'bbox') {
+      return convert_bbox(geometry);
+    } else if (type_of_geometry === 'polygon') {
+      return convert_polygon(geometry);
+    } else {
+      throw 'Invalid geometry type was specified. Please use either "point" or "polygon"';
     }
+  } catch(e) {
+    console.error(e);
+    throw e;
+  }
 }

--- a/packages/convert-geometry/test.js
+++ b/packages/convert-geometry/test.js
@@ -10,109 +10,109 @@ let geojson_point = JSON.parse(geojson_point_str);
 
 let array_bbox = [100.0, 0.0, 101.0, 1.0];
 
-let geojson_bbox_str = `{ 
-    "type": "Polygon",
-    "coordinates": [[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0],[100.0, 1.0], [100.0, 0.0]]]
+let geojson_bbox_str = `{
+  "type": "Polygon",
+  "coordinates": [[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0],[100.0, 1.0], [100.0, 0.0]]]
 }`;
 let geojson_bbox = JSON.parse(geojson_bbox_str);
 
 let array_polygon = [
-    [ [100.0, 0.0], [101.0, 0.0], [101.5, 1.0], [100.0, 0.5], [100.0, 0.0] ],
-    [ [100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.4], [100.2, 0.2] ]
+  [ [100.0, 0.0], [101.0, 0.0], [101.5, 1.0], [100.0, 0.5], [100.0, 0.0] ],
+  [ [100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.4], [100.2, 0.2] ]
 ];
 
-let geojson_polygon_str_1 = `{ 
-    "type": "Polygon",
-    "coordinates": [
-        [ [100.0, 0.0], [101.0, 0.0], [101.5, 1.0], [100.0, 0.5], [100.0, 0.0] ],
-        [ [100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.4], [100.2, 0.2] ]
-    ]
+let geojson_polygon_str_1 = `{
+  "type": "Polygon",
+  "coordinates": [
+    [ [100.0, 0.0], [101.0, 0.0], [101.5, 1.0], [100.0, 0.5], [100.0, 0.0] ],
+    [ [100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.4], [100.2, 0.2] ]
+  ]
 }`;
 
-let geojson_polygon_str_2 = `{ 
-    "type": "FeatureCollection",
-    "features": [
-        { "type": "Feature",
-            "geometry": {
-                "type": "Polygon",
-                "coordinates": [
-                    [ [100.0, 0.0], [101.0, 0.1], [101.5, 1.0], [100.0, 0.5], [100.0, 0.0] ]
-                ]
-            },
-            "properties": {
-                "prop0": "value0",
-                "prop1": {"this": "that"}
-            }
-         }
-    ]
+let geojson_polygon_str_2 = `{
+  "type": "FeatureCollection",
+  "features": [
+    { "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [ [100.0, 0.0], [101.0, 0.1], [101.5, 1.0], [100.0, 0.5], [100.0, 0.0] ]
+        ]
+      },
+      "properties": {
+        "prop0": "value0",
+        "prop1": {"this": "that"}
+      }
+     }
+  ]
 }`
 
 let geojson_polygon_1 = JSON.parse(geojson_polygon_str_1);
 let geojson_polygon_2 = JSON.parse(geojson_polygon_str_2);
 
 let test_point_load = feature => {
-    let point = gio_convert_geometry('point', feature);
-    expect(point[0]).to.equal(102);
-    expect(point[1]).to.equal(0.5);
+  let point = gio_convert_geometry('point', feature);
+  expect(point[0]).to.equal(102);
+  expect(point[1]).to.equal(0.5);
 }
 
 let test_bbox_load = feature => {
-    let bbox = gio_convert_geometry('bbox', feature);
-    expect(bbox.xmin).to.equal(100);
-    expect(bbox.ymin).to.equal(0);
-    expect(bbox.xmax).to.equal(101);
-    expect(bbox.ymax).to.equal(1);
+  let bbox = gio_convert_geometry('bbox', feature);
+  expect(bbox.xmin).to.equal(100);
+  expect(bbox.ymin).to.equal(0);
+  expect(bbox.xmax).to.equal(101);
+  expect(bbox.ymax).to.equal(1);
 }
 
 let test_polygon_load = feature => {
-    let polygon = gio_convert_geometry('polygon', feature);
+  let polygon = gio_convert_geometry('polygon', feature);
 
 }
 
 let test = () => {
-    describe('Gio Convert Geometry Feature', () => {
-        describe('Load point geometry', () => {
-            it('Loaded from array', () => {
-                test_point_load(array_point);
-            });
-            it('Loaded from geojson string', () => {
-                test_point_load(geojson_point_str);
-            });
-            it('Loaded from geojson obj', () => {
-                test_point_load(geojson_point);
-            });
-        });
+  describe('Gio Convert Geometry Feature', () => {
+    describe('Load point geometry', () => {
+      it('Loaded from array', () => {
+        test_point_load(array_point);
+      });
+      it('Loaded from geojson string', () => {
+        test_point_load(geojson_point_str);
+      });
+      it('Loaded from geojson obj', () => {
+        test_point_load(geojson_point);
+      });
+    });
 
-        describe('Load bbox geometry', () => {
-            it('Loaded from array', () => {
-                test_bbox_load(array_bbox);
-            });
-            it('Loaded from geojson string', () => {
-                test_bbox_load(geojson_bbox_str);
-            });
-            it('Loaded from geojson obj', () => {
-                test_bbox_load(geojson_bbox);
-            });
-        });
+    describe('Load bbox geometry', () => {
+      it('Loaded from array', () => {
+        test_bbox_load(array_bbox);
+      });
+      it('Loaded from geojson string', () => {
+        test_bbox_load(geojson_bbox_str);
+      });
+      it('Loaded from geojson obj', () => {
+        test_bbox_load(geojson_bbox);
+      });
+    });
 
-        describe('Load polygon geometry', () => {
-            it('Loaded from array', () => {
-                test_polygon_load(array_polygon);
-            });
-            it('Loaded from geojson string (simple)', () => {
-                test_polygon_load(geojson_polygon_str_1);
-            });
-            it('Loaded from geojson string (complex)', () => {
-                test_polygon_load(geojson_polygon_str_2);
-            });
-            it('Loaded from geojson obj (simple)', () => {
-                test_polygon_load(geojson_polygon_1);
-            });
-            it('Loaded from geojson obj (complex)', () => {
-                test_polygon_load(geojson_polygon_2);
-            });
-        })
+    describe('Load polygon geometry', () => {
+      it('Loaded from array', () => {
+        test_polygon_load(array_polygon);
+      });
+      it('Loaded from geojson string (simple)', () => {
+        test_polygon_load(geojson_polygon_str_1);
+      });
+      it('Loaded from geojson string (complex)', () => {
+        test_polygon_load(geojson_polygon_str_2);
+      });
+      it('Loaded from geojson obj (simple)', () => {
+        test_polygon_load(geojson_polygon_1);
+      });
+      it('Loaded from geojson obj (complex)', () => {
+        test_polygon_load(geojson_polygon_2);
+      });
     })
+  })
 }
 
 test();

--- a/packages/convert-geometry/test.js
+++ b/packages/convert-geometry/test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 let expect = require('chai').expect;
-let gio_convert_geometry = require('./convert-geometry');
+let geoblaze_convert_geometry = require('./convert-geometry');
 
 let array_point = [102, 0.5];
 
@@ -51,13 +51,13 @@ let geojson_polygon_1 = JSON.parse(geojson_polygon_str_1);
 let geojson_polygon_2 = JSON.parse(geojson_polygon_str_2);
 
 let test_point_load = feature => {
-  let point = gio_convert_geometry('point', feature);
+  let point = geoblaze_convert_geometry('point', feature);
   expect(point[0]).to.equal(102);
   expect(point[1]).to.equal(0.5);
 }
 
 let test_bbox_load = feature => {
-  let bbox = gio_convert_geometry('bbox', feature);
+  let bbox = geoblaze_convert_geometry('bbox', feature);
   expect(bbox.xmin).to.equal(100);
   expect(bbox.ymin).to.equal(0);
   expect(bbox.xmax).to.equal(101);
@@ -65,7 +65,7 @@ let test_bbox_load = feature => {
 }
 
 let test_polygon_load = feature => {
-  let polygon = gio_convert_geometry('polygon', feature);
+  let polygon = geoblaze_convert_geometry('polygon', feature);
 
 }
 

--- a/packages/get/get.js
+++ b/packages/get/get.js
@@ -6,87 +6,87 @@ let convert_geometry = require('../convert-geometry/convert-geometry');
 
 module.exports = (georaster, geom, flat) => {
 
-    let crop_top; let crop_left; let crop_right; let crop_bottom;  
+  let crop_top; let crop_left; let crop_right; let crop_bottom;
 
-    if (geom === null || geom === undefined) {
-
-        try {
-
-            if (flat) {
-
-                crop_bottom = georaster.height;
-                crop_left = 0;
-                crop_right = georaster.width;
-                crop_top = 0;
-
-            } else {
-
-                return georaster.values;
-
-            }
-
-        } catch (error) {
-
-            console.error(error);
-            throw error;
-
-        }
-     
-    } else if (utils.is_bbox(geom)) { // bounding box
-
-        try {
-
-        
-            // convert geometry
-            let geometry = convert_geometry('bbox', geom);
-
-            // use a utility function that converts from the lat/long coordinate
-            // space to the image coordinate space
-            // // left, top, right, bottom
-            let bbox = utils.convert_crs_bbox_to_image_bbox(georaster, geometry);
-            let bbox_left = bbox.xmin;
-            let bbox_top = bbox.ymin;
-            let bbox_right = bbox.xmax;
-            let bbox_bottom = bbox.ymax;
-
-            crop_top = Math.max(bbox_top, 0)
-            crop_left = Math.max(bbox_left, 0);
-            crop_right = Math.min(bbox_right, georaster.width);
-            crop_bottom = Math.min(bbox_bottom, georaster.height)
-
-        } catch (error) {
-
-            console.error(error);
-            throw error;
-
-        }
-
-    } else {
-
-        throw 'Geometry is not a bounding box - please make sure to send a bounding box when using gio-get';
-
-    }
+  if (geom === null || geom === undefined) {
 
     try {
 
-         if (flat) {
-            return georaster.values.map(band => {
-                let values = [];
-                for (let row_index = crop_top; row_index < crop_bottom; row_index++) {
-                   values = values.concat(Array.prototype.slice.call(band[row_index].slice(crop_left, crop_right)));
-                }
-                return values;
-            });
-        } else {
-            return georaster.values.map(band => {
-                let table = [];
-                for (let row_index = crop_top; row_index < crop_bottom; row_index++) {
-                    table.push(band[row_index].slice(crop_left, crop_right));
-                }
-                return table;
-            });
-        }
-    } catch (e) {
-        throw e;
+      if (flat) {
+
+        crop_bottom = georaster.height;
+        crop_left = 0;
+        crop_right = georaster.width;
+        crop_top = 0;
+
+      } else {
+
+        return georaster.values;
+
+      }
+
+    } catch (error) {
+
+      console.error(error);
+      throw error;
+
     }
+
+  } else if (utils.is_bbox(geom)) { // bounding box
+
+    try {
+
+
+      // convert geometry
+      let geometry = convert_geometry('bbox', geom);
+
+      // use a utility function that converts from the lat/long coordinate
+      // space to the image coordinate space
+      // // left, top, right, bottom
+      let bbox = utils.convert_crs_bbox_to_image_bbox(georaster, geometry);
+      let bbox_left = bbox.xmin;
+      let bbox_top = bbox.ymin;
+      let bbox_right = bbox.xmax;
+      let bbox_bottom = bbox.ymax;
+
+      crop_top = Math.max(bbox_top, 0)
+      crop_left = Math.max(bbox_left, 0);
+      crop_right = Math.min(bbox_right, georaster.width);
+      crop_bottom = Math.min(bbox_bottom, georaster.height)
+
+    } catch (error) {
+
+      console.error(error);
+      throw error;
+
+    }
+
+  } else {
+
+    throw 'Geometry is not a bounding box - please make sure to send a bounding box when using gio-get';
+
+  }
+
+  try {
+
+     if (flat) {
+      return georaster.values.map(band => {
+        let values = [];
+        for (let row_index = crop_top; row_index < crop_bottom; row_index++) {
+           values = values.concat(Array.prototype.slice.call(band[row_index].slice(crop_left, crop_right)));
+        }
+        return values;
+      });
+    } else {
+      return georaster.values.map(band => {
+        let table = [];
+        for (let row_index = crop_top; row_index < crop_bottom; row_index++) {
+          table.push(band[row_index].slice(crop_left, crop_right));
+        }
+        return table;
+      });
+    }
+  } catch (e) {
+    throw e;
+  }
 }

--- a/packages/get/get.js
+++ b/packages/get/get.js
@@ -63,7 +63,7 @@ module.exports = (georaster, geom, flat) => {
 
   } else {
 
-    throw 'Geometry is not a bounding box - please make sure to send a bounding box when using gio-get';
+    throw 'Geometry is not a bounding box - please make sure to send a bounding box when using geoblaze.get';
 
   }
 

--- a/packages/get/test.js
+++ b/packages/get/test.js
@@ -8,40 +8,40 @@ let url_rwanda = 'http://localhost:3000/data/RWA_MNH_ANC.tif';
 let bbox_rwanda = require("../../data/RwandaBufferedBoundingBox.json");
 
 let test = () => {
-    describe('Get Values', function() {
-        describe('Get Flat Values when Geom bigger than Raster', function() {
-            this.timeout(1000000);
-            it('Got Correct Flat Values', () => {
-                return load(url_rwanda).then(georaster => {
-                    let actual_values = get(georaster, bbox_rwanda, true);
-                    expect(actual_values).to.have.lengthOf(1);
-                    expect(actual_values[0]).to.have.lengthOf(georaster.height * georaster.width);
-                });
-            });
+  describe('Get Values', function() {
+    describe('Get Flat Values when Geom bigger than Raster', function() {
+      this.timeout(1000000);
+      it('Got Correct Flat Values', () => {
+        return load(url_rwanda).then(georaster => {
+          let actual_values = get(georaster, bbox_rwanda, true);
+          expect(actual_values).to.have.lengthOf(1);
+          expect(actual_values[0]).to.have.lengthOf(georaster.height * georaster.width);
         });
-        describe('Get 2-D Values when Geom bigger than Raster', function() {
-            this.timeout(1000000);
-            it('Got Correct 2-D Values', () => {
-                return load(url_rwanda).then(georaster => {
-                    let actual_values = get(georaster, bbox_rwanda, false);
-                    expect(actual_values).to.have.lengthOf(1);
-                    expect(actual_values[0]).to.have.lengthOf(georaster.height);
-                    expect(actual_values[0][0]).to.have.lengthOf(georaster.width);
-                });
-            });
+      });
+    });
+    describe('Get 2-D Values when Geom bigger than Raster', function() {
+      this.timeout(1000000);
+      it('Got Correct 2-D Values', () => {
+        return load(url_rwanda).then(georaster => {
+          let actual_values = get(georaster, bbox_rwanda, false);
+          expect(actual_values).to.have.lengthOf(1);
+          expect(actual_values[0]).to.have.lengthOf(georaster.height);
+          expect(actual_values[0][0]).to.have.lengthOf(georaster.width);
         });
-        describe('Get flat values for whole raster', function() {
-            this.timeout(1000000);
-            it('Got Correct flat values', () => {
-                return load(url_rwanda).then(georaster => {
-                    let flat = true;
-                    let actual_values = get(georaster, null, flat);
-                    expect(actual_values).to.have.lengthOf(1);
-                    expect(actual_values[0]).to.have.lengthOf(georaster.height * georaster.width);
-                });
-            });
+      });
+    });
+    describe('Get flat values for whole raster', function() {
+      this.timeout(1000000);
+      it('Got Correct flat values', () => {
+        return load(url_rwanda).then(georaster => {
+          let flat = true;
+          let actual_values = get(georaster, null, flat);
+          expect(actual_values).to.have.lengthOf(1);
+          expect(actual_values[0]).to.have.lengthOf(georaster.height * georaster.width);
         });
-    })
+      });
+    });
+  })
 }
 
 test();

--- a/packages/histogram/histogram.js
+++ b/packages/histogram/histogram.js
@@ -11,139 +11,139 @@ const logger = require('../../logger');
 
 const get_equal_interval_bins = (values, num_classes) => {
 
-    // get min and max values
-    const min_value = _.min(values);
-    const max_value = _.max(values);
+  // get min and max values
+  const min_value = _.min(values);
+  const max_value = _.max(values);
 
-    // specify bins, bins represented as a list of [min, max] values
-    // and are divided up based on number of classes
-    const interval = (max_value - min_value) / num_classes;
-    const bins = _.range(num_classes).map((num, index) => {
-        const start = Number((min_value + num * interval).toFixed(2));
-        const end = Number((min_value + (num + 1) * interval).toFixed(2));
-        return [start, end];
-    });
+  // specify bins, bins represented as a list of [min, max] values
+  // and are divided up based on number of classes
+  const interval = (max_value - min_value) / num_classes;
+  const bins = _.range(num_classes).map((num, index) => {
+    const start = Number((min_value + num * interval).toFixed(2));
+    const end = Number((min_value + (num + 1) * interval).toFixed(2));
+    return [start, end];
+  });
 
-    let results = {};
+  let results = {};
 
-    // set first bin in results to eliminate the need to check
-    // for the existence of the key in every iteration
-    let bin_index = 0;
-    let bin = bins[bin_index];
-    let bin_key = `${bin[0]} - ${bin[1]}`;
-    let first_value = values[0];
+  // set first bin in results to eliminate the need to check
+  // for the existence of the key in every iteration
+  let bin_index = 0;
+  let bin = bins[bin_index];
+  let bin_key = `${bin[0]} - ${bin[1]}`;
+  let first_value = values[0];
 
-    while (first_value > bin[1]) { // this is in case the first value isn't in the first bin
+  while (first_value > bin[1]) { // this is in case the first value isn't in the first bin
+    bin_index += 1;
+    bin = bins[bin_key];
+    bin_key = `>${bin[0]} - ${bin[1]}`;
+  }
+  results[bin_key] = 1;
+
+  // add to results based on bins
+  for (var i = 1; i < values.length; i++) {
+    let value = values[i];
+    if (value <= bin[1]) { // add to existing bin if its in the correct range
+      results[bin_key] += 1;
+    } else { // otherwise keep searching for an appropriate bin until one is found
+      while (value > bin[1]) {
         bin_index += 1;
-        bin = bins[bin_key];
+        bin = bins[bin_index];
         bin_key = `>${bin[0]} - ${bin[1]}`;
+      }
+      results[bin_key] = 1; // initialize that bin with the first occupant
     }
-    results[bin_key] = 1;
+  }
 
-    // add to results based on bins
-    for (var i = 1; i < values.length; i++) {
-        let value = values[i];
-        if (value <= bin[1]) { // add to existing bin if its in the correct range
-            results[bin_key] += 1;
-        } else { // otherwise keep searching for an appropriate bin until one is found
-            while (value > bin[1]) {
-                bin_index += 1;
-                bin = bins[bin_index];
-                bin_key = `>${bin[0]} - ${bin[1]}`;
-            }
-            results[bin_key] = 1; // initialize that bin with the first occupant
-        }
-    }
-
-    return results;
+  return results;
 }
 
 const get_quantile_bins = (values, num_classes) => {
 
-    // get the number of values in each bin
-    const values_per_bin = values.length / num_classes;
+  // get the number of values in each bin
+  const values_per_bin = values.length / num_classes;
 
-    // iterate through values and use a counter to
-    // decide when to set up the next bin. Bins are
-    // represented as a list of [min, max] values
-    let results = {}
-    let bin_index = 0;
-    let bin_min = values[0];
-    let num_values_in_current_bin = 1;
-    for (var i = 1; i < values.length; i++) {
-        if (num_values_in_current_bin + 1 < values_per_bin) {
-            num_values_in_current_bin += 1;
-        } else { // if it is the last value, add it to the bin and start setting up for the next one
-            let value = values[i];
-            let bin_max = value;
-            num_values_in_current_bin += 1;
-            if (_.keys(results).length > 0) bin_min = `>${bin_min}`;
-            results[`${bin_min} - ${bin_max}`] = num_values_in_current_bin;
-            num_values_in_current_bin = 0;
-            bin_min = value;
-        }
+  // iterate through values and use a counter to
+  // decide when to set up the next bin. Bins are
+  // represented as a list of [min, max] values
+  let results = {}
+  let bin_index = 0;
+  let bin_min = values[0];
+  let num_values_in_current_bin = 1;
+  for (var i = 1; i < values.length; i++) {
+    if (num_values_in_current_bin + 1 < values_per_bin) {
+      num_values_in_current_bin += 1;
+    } else { // if it is the last value, add it to the bin and start setting up for the next one
+      let value = values[i];
+      let bin_max = value;
+      num_values_in_current_bin += 1;
+      if (_.keys(results).length > 0) bin_min = `>${bin_min}`;
+      results[`${bin_min} - ${bin_max}`] = num_values_in_current_bin;
+      num_values_in_current_bin = 0;
+      bin_min = value;
     }
+  }
 
-    // add the last bin
-    const bin_max = values[values.length - 1];
-    num_values_in_current_bin += 1;
-    bin_min = `>${bin_min}`;
-    results[`${bin_min} - ${bin_max}`] = num_values_in_current_bin;
+  // add the last bin
+  const bin_max = values[values.length - 1];
+  num_values_in_current_bin += 1;
+  bin_min = `>${bin_min}`;
+  results[`${bin_min} - ${bin_max}`] = num_values_in_current_bin;
 
-    return results;
+  return results;
 }
 
 const get_histogram = (values, options) => {
 
-    // pull out options, possible options are:
-    // scale_type: measurement scale, options are: nominal, ratio
-    // num_classes: number of classes/bins, only available for ratio data
-    // class_type: method of breaking data into classes, only available
-    //             for ratio data, options are: equal-interval, quantile
-    //
-    var options = options || {};
-    const scale_type = options.scale_type;
-    const num_classes = options.num_classes;
-    const class_type = options.class_type;
+  // pull out options, possible options are:
+  // scale_type: measurement scale, options are: nominal, ratio
+  // num_classes: number of classes/bins, only available for ratio data
+  // class_type: method of breaking data into classes, only available
+  //       for ratio data, options are: equal-interval, quantile
+  //
+  var options = options || {};
+  const scale_type = options.scale_type;
+  const num_classes = options.num_classes;
+  const class_type = options.class_type;
 
-    if (!scale_type) {
-        throw 'Insufficient options were provided, need a value for "scale_type." Possible values include "nominal" and "ratio".';
+  if (!scale_type) {
+    throw 'Insufficient options were provided, need a value for "scale_type." Possible values include "nominal" and "ratio".';
+  }
+
+  let results;
+
+  // when working with nominal data, we simply create a new object attribute
+  // for every new value, and increment for each additional value.
+  if (scale_type === 'nominal') {
+    results = {};
+    for (let i = 0; i < values.length; i++) {
+      let value = values[i];
+      if (results[value]) results[value] += 1;
+      else results[value] = 1;
+    }
+  } else if (scale_type === 'ratio') {
+    results = {};
+
+    if (!num_classes) {
+      throw 'Insufficient options were provided, need a value for "num_classes".';
+    } else if (!class_type) {
+      throw 'Insufficient options were provided, need a value for "class_type". Possible values include "equal-interval" and "quantile"';
     }
 
-    let results;
+    // sort values to make binning more efficient
+    values = values.sort((a, b) => a - b);
 
-    // when working with nominal data, we simply create a new object attribute
-    // for every new value, and increment for each additional value.
-    if (scale_type === 'nominal') {
-        results = {};
-        for (let i = 0; i < values.length; i++) {
-            let value = values[i];
-            if (results[value]) results[value] += 1;
-            else results[value] = 1;
-        }
-    } else if (scale_type === 'ratio') {
-        results = {};
-
-        if (!num_classes) {
-            throw 'Insufficient options were provided, need a value for "num_classes".';
-        } else if (!class_type) {
-            throw 'Insufficient options were provided, need a value for "class_type". Possible values include "equal-interval" and "quantile"';
-        }
-
-        // sort values to make binning more efficient
-        values = values.sort((a, b) => a - b);
-
-        if (class_type === 'equal-interval') {
-            results = get_equal_interval_bins(values, num_classes);
-        } else if (class_type === 'quantile') {
-            results = get_quantile_bins(values, num_classes);
-        } else {
-            throw 'The class_type provided is either not supported or incorrectly specified.';
-        }
+    if (class_type === 'equal-interval') {
+      results = get_equal_interval_bins(values, num_classes);
+    } else if (class_type === 'quantile') {
+      results = get_quantile_bins(values, num_classes);
+    } else {
+      throw 'The class_type provided is either not supported or incorrectly specified.';
     }
+  }
 
-    if (results) return results;
-    else throw 'An unexpected error occurred while running the get_histogram function.';
+  if (results) return results;
+  else throw 'An unexpected error occurred while running the get_histogram function.';
 }
 
 /**
@@ -160,49 +160,49 @@ const get_histogram = (values, options) => {
  */
 function get_histograms_for_raster(georaster, geom, options) {
 
-    try {
+  try {
 
-        logger.info('starting get_histograms_for_raster');
+    logger.info('starting get_histograms_for_raster');
 
-        if (utils.is_bbox(geom)) {
-            geom = convert_geometry('bbox', geom);
-            var no_data_value = georaster.no_data_value;
+    if (utils.is_bbox(geom)) {
+      geom = convert_geometry('bbox', geom);
+      var no_data_value = georaster.no_data_value;
 
-            // grab array of values by band
-            let flat = true;
-            let values = get(georaster, geom, true);
+      // grab array of values by band
+      let flat = true;
+      let values = get(georaster, geom, true);
 
-            // run through histogram function
-            return values
-                .map(band => band.filter(value => value !== no_data_value))
-                .map(band => get_histogram(band, options));
+      // run through histogram function
+      return values
+        .map(band => band.filter(value => value !== no_data_value))
+        .map(band => get_histogram(band, options));
 
-        } else if (utils.is_polygon(geom)) {
-            geom = convert_geometry('polygon', geom);
-            let no_data_value = georaster.no_data_value;
+    } else if (utils.is_polygon(geom)) {
+      geom = convert_geometry('polygon', geom);
+      let no_data_value = georaster.no_data_value;
 
-            // grab array of values by band
-            let values = [];
-            intersect_polygon(georaster, geom, (value, band_index) => {
-                if (values[band_index]) {
-                    values[band_index].push(value);
-                } else {
-                    values[band_index] = [value];
-                }
-            });
-
-            values = values.map(band => band.filter(value => value !== no_data_value));
-
-            // run through histogram function
-            return values.map(band => get_histogram(band, options));
-
+      // grab array of values by band
+      let values = [];
+      intersect_polygon(georaster, geom, (value, band_index) => {
+        if (values[band_index]) {
+          values[band_index].push(value);
         } else {
-            throw 'Only Bounding Box and Polygon geometries are currently supported.'
+          values[band_index] = [value];
         }
-    } catch(e) {
-        console.error(e);
-        throw e;
+      });
+
+      values = values.map(band => band.filter(value => value !== no_data_value));
+
+      // run through histogram function
+      return values.map(band => get_histogram(band, options));
+
+    } else {
+      throw 'Only Bounding Box and Polygon geometries are currently supported.'
     }
+  } catch(e) {
+    console.error(e);
+    throw e;
+  }
 }
 
 module.exports = get_histograms_for_raster;

--- a/packages/histogram/test.js
+++ b/packages/histogram/test.js
@@ -6,28 +6,28 @@ let load = require('./../load/load');
 let histogram = require('./histogram');
 
 let ratio_quantile_options = {
-    scale_type: 'ratio',
-    num_classes: 7,
-    class_type: 'quantile'
+  scale_type: 'ratio',
+  num_classes: 7,
+  class_type: 'quantile'
 }
 
 let ratio_ei_options = {
-    scale_type: 'ratio',
-    num_classes: 7,
-    class_type: 'equal-interval'
+  scale_type: 'ratio',
+  num_classes: 7,
+  class_type: 'equal-interval'
 }
 
 let ratio_quantile_bbox_results = {
-    '0 - 93.2': 31,
-    '>93.2 - 272': 31,
-    '>272 - 724': 31,
-    '>724 - 1141.9': 31,
-    '>1141.9 - 1700.6': 31,
-    '>1700.6 - 2732.4': 31,
-    '>2732.4 - 5166.7': 28 }
+  '0 - 93.2': 31,
+  '>93.2 - 272': 31,
+  '>272 - 724': 31,
+  '>724 - 1141.9': 31,
+  '>1141.9 - 1700.6': 31,
+  '>1700.6 - 2732.4': 31,
+  '>2732.4 - 5166.7': 28 }
 
 let ratio_quantile_polygon_results = {
-    '0 - 129.3': 248,
+  '0 - 129.3': 248,
   '>129.3 - 683.8': 248,
   '>683.8 - 1191': 248,
   '>1191 - 1948.7': 248,
@@ -37,13 +37,13 @@ let ratio_quantile_polygon_results = {
 };
 
 let ratio_ei_polygon_results = {
-    '0 - 1115.34': 719,
-    '>1115.34 - 2230.69': 373,
-    '>2230.69 - 3346.03': 359,
-    '>3346.03 - 4461.37': 170,
-    '>4461.37 - 5576.71': 78,
-    '>5576.71 - 6692.06': 25,
-    '>6692.06 - 7807.4': 9
+  '0 - 1115.34': 719,
+  '>1115.34 - 2230.69': 373,
+  '>2230.69 - 3346.03': 359,
+  '>3346.03 - 4461.37': 170,
+  '>4461.37 - 5576.71': 78,
+  '>5576.71 - 6692.06': 25,
+  '>6692.06 - 7807.4': 9
 }
 
 let url = 'http://localhost:3000/data/test.tiff';
@@ -51,75 +51,75 @@ let url = 'http://localhost:3000/data/test.tiff';
 let bbox = [80.63, 7.42, 84.21, 10.10];
 
 let polygon = [[
-    [83.12255859375, 22.49225722008518], [82.96875, 21.57571893245848], [81.58447265624999,  1.207458730482642],
-    [83.07861328125, 20.34462694382967], [83.8037109375,  19.497664168139053], [84.814453125, 19.766703551716976],
-    [85.078125, 21.166483858206583], [86.044921875, 20.838277806058933], [86.98974609375, 22.49225722008518],
-    [85.58349609375, 24.54712317973075], [84.6826171875, 23.36242859340884], [83.12255859375, 22.49225722008518]
+  [83.12255859375, 22.49225722008518], [82.96875, 21.57571893245848], [81.58447265624999,  1.207458730482642],
+  [83.07861328125, 20.34462694382967], [83.8037109375,  19.497664168139053], [84.814453125, 19.766703551716976],
+  [85.078125, 21.166483858206583], [86.044921875, 20.838277806058933], [86.98974609375, 22.49225722008518],
+  [85.58349609375, 24.54712317973075], [84.6826171875, 23.36242859340884], [83.12255859375, 22.49225722008518]
 ]];
 
 let polygon_geojson = `{
-    "type": "FeatureCollection",
-    "features": [
-        { "type": "Feature",
-            "geometry": {
-                "type": "Polygon",
-                "coordinates": [[
-                    [83.12255859375, 22.49225722008518], [82.96875, 21.57571893245848], [81.58447265624999,  1.207458730482642],
-                    [83.07861328125, 20.34462694382967], [83.8037109375,  19.497664168139053], [84.814453125, 19.766703551716976],
-                    [85.078125, 21.166483858206583], [86.044921875, 20.838277806058933], [86.98974609375, 22.49225722008518],
-                    [85.58349609375, 24.54712317973075], [84.6826171875, 23.36242859340884], [83.12255859375, 22.49225722008518]
-                ]]
-            },
-            "properties": {
-                "prop0": "value0",
-                "prop1": {"this": "that"}
-            }
-         }
-    ]
+  "type": "FeatureCollection",
+  "features": [
+    { "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+          [83.12255859375, 22.49225722008518], [82.96875, 21.57571893245848], [81.58447265624999,  1.207458730482642],
+          [83.07861328125, 20.34462694382967], [83.8037109375,  19.497664168139053], [84.814453125, 19.766703551716976],
+          [85.078125, 21.166483858206583], [86.044921875, 20.838277806058933], [86.98974609375, 22.49225722008518],
+          [85.58349609375, 24.54712317973075], [84.6826171875, 23.36242859340884], [83.12255859375, 22.49225722008518]
+        ]]
+      },
+      "properties": {
+        "prop0": "value0",
+        "prop1": {"this": "that"}
+      }
+     }
+  ]
 }`
 
 let test = () => {
-    describe('Gio Histogram Feature', function() {
-        describe('Get Histogram (Ratio, Quantile) from Bounding Box', function() {
-            this.timeout(1000000);
-            it('Got Correct Value', () => {
-                return load(url).then(georaster => {
-                    let results = histogram(georaster, bbox, ratio_quantile_options)[0];
-                    _.keys(ratio_quantile_bbox_results).forEach(key => {
-                        let value = results[key];
-                        let expected_value = ratio_quantile_bbox_results[key];
-                        expect(value).to.equal(expected_value);
-                    });
-                });
-            });
+  describe('Gio Histogram Feature', function() {
+    describe('Get Histogram (Ratio, Quantile) from Bounding Box', function() {
+      this.timeout(1000000);
+      it('Got Correct Value', () => {
+        return load(url).then(georaster => {
+          let results = histogram(georaster, bbox, ratio_quantile_options)[0];
+          _.keys(ratio_quantile_bbox_results).forEach(key => {
+            let value = results[key];
+            let expected_value = ratio_quantile_bbox_results[key];
+            expect(value).to.equal(expected_value);
+          });
         });
-        describe('Get Histogram (Ratio, Quantile) from Polygon', function() {
-            this.timeout(1000000);
-            it('Got Correct Value', () => {
-                return load(url).then(georaster => {
-                    let results = histogram(georaster, polygon, ratio_quantile_options)[0];
-                    _.keys(ratio_quantile_polygon_results).forEach(key => {
-                        let value = results[key];
-                        let expected_value = ratio_quantile_polygon_results[key];
-                        expect(value).to.equal(expected_value);
-                    });
-                })
-            })
-        });
-        describe('Get Histogram (Ratio, Equal Interval) from Polygon (GeoJSON)', function() {
-            this.timeout(1000000);
-            it('Got Correct Value', () => {
-                return load(url).then(georaster => {
-                    let results = histogram(georaster, polygon_geojson, ratio_ei_options)[0];
-                    _.keys(ratio_quantile_bbox_results).forEach(key => {
-                        let value = results[key];
-                        let expected_value = ratio_ei_polygon_results[key];
-                        expect(value).to.equal(expected_value);
-                    });
-                })
-            })
+      });
+    });
+    describe('Get Histogram (Ratio, Quantile) from Polygon', function() {
+      this.timeout(1000000);
+      it('Got Correct Value', () => {
+        return load(url).then(georaster => {
+          let results = histogram(georaster, polygon, ratio_quantile_options)[0];
+          _.keys(ratio_quantile_polygon_results).forEach(key => {
+            let value = results[key];
+            let expected_value = ratio_quantile_polygon_results[key];
+            expect(value).to.equal(expected_value);
+          });
         })
+      })
+    });
+    describe('Get Histogram (Ratio, Equal Interval) from Polygon (GeoJSON)', function() {
+      this.timeout(1000000);
+      it('Got Correct Value', () => {
+        return load(url).then(georaster => {
+          let results = histogram(georaster, polygon_geojson, ratio_ei_options)[0];
+          _.keys(ratio_quantile_bbox_results).forEach(key => {
+            let value = results[key];
+            let expected_value = ratio_ei_polygon_results[key];
+            expect(value).to.equal(expected_value);
+          });
+        })
+      })
     })
+  })
 }
 
 test();

--- a/packages/histogram/test.js
+++ b/packages/histogram/test.js
@@ -79,7 +79,7 @@ let polygon_geojson = `{
 }`
 
 let test = () => {
-  describe('Gio Histogram Feature', function() {
+  describe('Geoblaze Histogram Feature', function() {
     describe('Get Histogram (Ratio, Quantile) from Bounding Box', function() {
       this.timeout(1000000);
       it('Got Correct Value', () => {

--- a/packages/identify/identify.js
+++ b/packages/identify/identify.js
@@ -4,44 +4,44 @@ let load = require('../load/load');
 let convert_geometry = require('../convert-geometry/convert-geometry');
 
 /**
-    Given a raster and a point geometry,
-    the identify function returns the pixel
-    value of the raster at the given point.
+  Given a raster and a point geometry,
+  the identify function returns the pixel
+  value of the raster at the given point.
 
-    @param {object} raster - a raster from the georaster library
-    @param {string|object} geometry - geometry can be an [x,y] array, a GeoJSON point object, or a string representation of a GeoJSON point object.
+  @param {object} raster - a raster from the georaster library
+  @param {string|object} geometry - geometry can be an [x,y] array, a GeoJSON point object, or a string representation of a GeoJSON point object.
 */
 let identify = (georaster, geometry) => {
 
-    // The convert_geometry function takes the input
-    // geometry and converts it to a standard format.
-    let point = convert_geometry('point', geometry);
-    let x_in_crs = point[0];
-    let y_in_crs = point[1];
+  // The convert_geometry function takes the input
+  // geometry and converts it to a standard format.
+  let point = convert_geometry('point', geometry);
+  let x_in_crs = point[0];
+  let y_in_crs = point[1];
 
 
-    // By normalizing the difference in yitude and longitude between the image
-    // origin and the point geometry by the cell height and width respectively,
-    // we can map the yitude and longitude of the point geometry in the
-    // coordinate space to their associated pixel location in the image space.
-    // Note that the y value is inverted to account for the inversion between the
-    // coordinate and image spaces.
-    let x = Math.floor((x_in_crs - georaster.xmin) / georaster.pixelWidth);
-    let y = Math.floor((georaster.ymax - y_in_crs) / georaster.pixelHeight);
+  // By normalizing the difference in yitude and longitude between the image
+  // origin and the point geometry by the cell height and width respectively,
+  // we can map the yitude and longitude of the point geometry in the
+  // coordinate space to their associated pixel location in the image space.
+  // Note that the y value is inverted to account for the inversion between the
+  // coordinate and image spaces.
+  let x = Math.floor((x_in_crs - georaster.xmin) / georaster.pixelWidth);
+  let y = Math.floor((georaster.ymax - y_in_crs) / georaster.pixelHeight);
 
-    try {
+  try {
 
-        // iterate through the bands
-        // get the row and then the column of the pixel that you want
-        if (x > 0 && x < georaster.width && y > 0 && y < georaster.height) {
-            return georaster.values.map(rows => rows[y][x]);
-        } else {
-            return null;
-        }
-
-    } catch(e) {
-        throw e;
+    // iterate through the bands
+    // get the row and then the column of the pixel that you want
+    if (x > 0 && x < georaster.width && y > 0 && y < georaster.height) {
+      return georaster.values.map(rows => rows[y][x]);
+    } else {
+      return null;
     }
+
+  } catch(e) {
+    throw e;
+  }
 }
 
 module.exports = identify;

--- a/packages/identify/test.js
+++ b/packages/identify/test.js
@@ -10,26 +10,26 @@ let point = [80.63, 7.42];
 let expected_value = 350.7;
 
 let test = () => (
-    describe('Gio Identify Feature', function() {
-        describe('Identify Point in Raster', function() {
-            this.timeout(1000000);
-            it('Identified Point Correctly', () => {
-                return load(url).then(georaster => {
-                    let value = identify(georaster, point)[0];
-                    expect(value).to.equal(expected_value);
-                });
-            });
+  describe('Gio Identify Feature', function() {
+    describe('Identify Point in Raster', function() {
+      this.timeout(1000000);
+      it('Identified Point Correctly', () => {
+        return load(url).then(georaster => {
+          let value = identify(georaster, point)[0];
+          expect(value).to.equal(expected_value);
         });
-        describe('Try to identify point outside raster', function() {
-            this.timeout(1000000);
-            it('Correctly returned null', () => {
-                return load(url).then(georaster => {
-                    let value = identify(georaster, [-200, 7.42]);
-                    expect(value).to.equal(null);
-                });
-            });
+      });
+    });
+    describe('Try to identify point outside raster', function() {
+      this.timeout(1000000);
+      it('Correctly returned null', () => {
+        return load(url).then(georaster => {
+          let value = identify(georaster, [-200, 7.42]);
+          expect(value).to.equal(null);
         });
-    })
+      });
+    });
+  })
 )
 
 test();

--- a/packages/identify/test.js
+++ b/packages/identify/test.js
@@ -10,7 +10,7 @@ let point = [80.63, 7.42];
 let expected_value = 350.7;
 
 let test = () => (
-  describe('Gio Identify Feature', function() {
+  describe('Geoblaze Identify Feature', function() {
     describe('Identify Point in Raster', function() {
       this.timeout(1000000);
       it('Identified Point Correctly', () => {

--- a/packages/intersect-polygon/intersect-polygon.js
+++ b/packages/intersect-polygon/intersect-polygon.js
@@ -22,333 +22,333 @@ const get_slope_of_line_segment = utils.get_slope_of_line_segment;
 const logger = require('../../logger');
 
 const get_edges_for_polygon = polygon => {
-    let edges = [];
-    polygon.forEach(ring => {
-        for (let i = 1; i < ring.length; i++) {
-            let start_point = ring[i - 1];
-            let end_point = ring[i];
-            edges.push([start_point, end_point]);
-        }
-    });
-    return edges;
+  let edges = [];
+  polygon.forEach(ring => {
+    for (let i = 1; i < ring.length; i++) {
+      let start_point = ring[i - 1];
+      let end_point = ring[i];
+      edges.push([start_point, end_point]);
+    }
+  });
+  return edges;
 };
 
 module.exports = (georaster, geom, run_this_function_on_each_pixel_inside_geometry) => {
 
-    let cell_width = georaster.pixelWidth;
-    let cell_height = georaster.pixelHeight;
-    logger.debug("cell_height:", cell_height);
+  let cell_width = georaster.pixelWidth;
+  let cell_height = georaster.pixelHeight;
+  logger.debug("cell_height:", cell_height);
 
-    let no_data_value = georaster.no_data_value;
-    let image_height = georaster.height;
-    logger.debug("image_height: " + image_height);
+  let no_data_value = georaster.no_data_value;
+  let image_height = georaster.height;
+  logger.debug("image_height: " + image_height);
 
-    let image_width = georaster.width;
+  let image_width = georaster.width;
 
-    // get values in a bounding box around the geometry
-    let latlng_bbox = utils.get_bounding_box(geom);
-    logger.debug("latlng_bbox:", latlng_bbox);
+  // get values in a bounding box around the geometry
+  let latlng_bbox = utils.get_bounding_box(geom);
+  logger.debug("latlng_bbox:", latlng_bbox);
 
-    let image_bands = get(georaster, latlng_bbox)
+  let image_bands = get(georaster, latlng_bbox)
 
-    // set origin points of bbox of geometry in image space
-    let lat_0 = latlng_bbox.ymax + ((georaster.ymax - latlng_bbox.ymax) % cell_height);
-    logger.debug("lat_0:", lat_0);
-    let lng_0 = latlng_bbox.xmin - ((latlng_bbox.xmin - georaster.xmin) % cell_width);
-    logger.debug("lng_0:", lng_0);
+  // set origin points of bbox of geometry in image space
+  let lat_0 = latlng_bbox.ymax + ((georaster.ymax - latlng_bbox.ymax) % cell_height);
+  logger.debug("lat_0:", lat_0);
+  let lng_0 = latlng_bbox.xmin - ((latlng_bbox.xmin - georaster.xmin) % cell_width);
+  logger.debug("lng_0:", lng_0);
 
-    // calculate size of bbox in image coordinates
-    // to derive out the row length
-    let image_bbox = utils.convert_crs_bbox_to_image_bbox(georaster, latlng_bbox);
-    logger.debug("image_bbox:", image_bbox);
+  // calculate size of bbox in image coordinates
+  // to derive out the row length
+  let image_bbox = utils.convert_crs_bbox_to_image_bbox(georaster, latlng_bbox);
+  logger.debug("image_bbox:", image_bbox);
 
-    let x_min = image_bbox.xmin,
-        y_min = image_bbox.ymin,
-        x_max = image_bbox.xmax,
-        y_max = image_bbox.ymax;
+  let x_min = image_bbox.xmin,
+    y_min = image_bbox.ymin,
+    x_max = image_bbox.xmax,
+    y_max = image_bbox.ymax;
 
-    let row_length = x_max - x_min;
-    logger.debug("row_length:", row_length);
+  let row_length = x_max - x_min;
+  logger.debug("row_length:", row_length);
 
-    // iterate through image rows and convert each one to a line
-    // running through the middle of the row
-    let image_lines = [];
-    let num_rows = image_bands[0].length;
+  // iterate through image rows and convert each one to a line
+  // running through the middle of the row
+  let image_lines = [];
+  let num_rows = image_bands[0].length;
 
-    if (num_rows === 0) return;
+  if (num_rows === 0) return;
 
-    logger.debug("num_rows:", num_rows);
-    for (let y = 0; y < num_rows; y++) {
+  logger.debug("num_rows:", num_rows);
+  for (let y = 0; y < num_rows; y++) {
 
-        let lat = lat_0 - cell_height * y - cell_height / 2;
+    let lat = lat_0 - cell_height * y - cell_height / 2;
 
-        // use that point, plus another point along the same latitude to
-        // create a line
-        let point_0 = [lng_0, lat];
-        let point_1 = [lng_0 + 1, lat];
-        let line = get_line_from_points(point_0, point_1);
-        image_lines.push(line);
-    }
-    logger.debug("image_lines.length:", image_lines.length);
-    logger.debug("image_lines[0]:", image_lines[0]);
-
-
-    // collapse geometry down to a list of edges
-    // necessary for multi-part geometries
-    let depth = utils.get_depth(geom);
-    logger.debug("depth:", depth);
-    let polygon_edges = depth === 4  ? geom.map(get_edges_for_polygon) : [get_edges_for_polygon(geom)];
-    logger.debug("polygon_edges.length:", polygon_edges.length);
-
-    polygon_edges.forEach((edges, edges_index) => {
-
-        logger.debug(() => {
-            console.log("edges.length", edges.length);
-            let target = 41.76184321688703;
-            let overlaps = [];
-            edges.forEach((edge, index) => {
-                let [[x1,y1], [x2,y2]] = edge;
-                let ymin = Math.min(y1, y2);
-                let ymax = Math.max(y1, y2);
-                if (target >= ymin && target <= ymax) {
-                    overlaps.push(JSON.stringify({ index, edge}));
-                }
-            });
-            console.log("overlaps:", overlaps);
-        });
-
-        // iterate through the list of polygon vertices, convert them to
-        // lines, and compute the intersections with each image row
-        let intersections_by_row = _.range(num_rows).map(row => []);
-        logger.debug("intersections_by_row.length:", intersections_by_row.length);
-        let number_of_edges = edges.length;
-        logger.debug("number_of_edges:", number_of_edges);
-        for (let i = 0; i < number_of_edges; i++) {
+    // use that point, plus another point along the same latitude to
+    // create a line
+    let point_0 = [lng_0, lat];
+    let point_1 = [lng_0 + 1, lat];
+    let line = get_line_from_points(point_0, point_1);
+    image_lines.push(line);
+  }
+  logger.debug("image_lines.length:", image_lines.length);
+  logger.debug("image_lines[0]:", image_lines[0]);
 
 
-            // get vertices that make up an edge and convert that to a line
-            let edge = edges[i];
+  // collapse geometry down to a list of edges
+  // necessary for multi-part geometries
+  let depth = utils.get_depth(geom);
+  logger.debug("depth:", depth);
+  let polygon_edges = depth === 4  ? geom.map(get_edges_for_polygon) : [get_edges_for_polygon(geom)];
+  logger.debug("polygon_edges.length:", polygon_edges.length);
 
-            let [start_point, end_point] = edge;
-            let [ x1, y1 ] = start_point;
-            let [ x2, y2 ] = end_point;
+  polygon_edges.forEach((edges, edges_index) => {
 
-            let direction = Math.sign(y2 - y1);
-            let horizontal = y1 === y2;
-            let vertical = x1 === x2;
+    logger.debug(() => {
+      console.log("edges.length", edges.length);
+      let target = 41.76184321688703;
+      let overlaps = [];
+      edges.forEach((edge, index) => {
+        let [[x1,y1], [x2,y2]] = edge;
+        let ymin = Math.min(y1, y2);
+        let ymax = Math.max(y1, y2);
+        if (target >= ymin && target <= ymax) {
+          overlaps.push(JSON.stringify({ index, edge}));
+        }
+      });
+      console.log("overlaps:", overlaps);
+    });
 
-            let edge_y = y1;
-
-            let edge_line = get_line_from_points(start_point, end_point);
-
-            let edge_ymin = Math.min(y1, y2);
-            let edge_ymax = Math.max(y1, y2);
-
-            logger.debug("\nedge", i, ":", edge);
-            logger.debug("direction:", direction);
-            logger.debug("horizontal:", horizontal);
-            logger.debug("vertical:", vertical);
-            logger.debug("edge_ymin:", edge_ymin);
-            logger.debug("edge_ymax:", edge_ymax);
-
-            let start_lng, start_lat, end_lat, end_lng;
-            if (x1 < x2) {
-                [ start_lng, start_lat ] = start_point;
-                [ end_lng, end_lat ] = end_point;
-            } else {
-                [ start_lng, start_lat ] = end_point;
-                [ end_lng, end_lat ]  = start_point;
-            }
+    // iterate through the list of polygon vertices, convert them to
+    // lines, and compute the intersections with each image row
+    let intersections_by_row = _.range(num_rows).map(row => []);
+    logger.debug("intersections_by_row.length:", intersections_by_row.length);
+    let number_of_edges = edges.length;
+    logger.debug("number_of_edges:", number_of_edges);
+    for (let i = 0; i < number_of_edges; i++) {
 
 
-            if (start_lng === undefined) throw Error("start_lng is " + start_lng);
+      // get vertices that make up an edge and convert that to a line
+      let edge = edges[i];
 
-            // find the y values in the image coordinate space
-            let y_1 = Math.round((lat_0 - .5*cell_height - start_lat ) / cell_height);
-            let y_2 = Math.round((lat_0 - .5*cell_height - end_lat) / cell_height);
+      let [start_point, end_point] = edge;
+      let [ x1, y1 ] = start_point;
+      let [ x2, y2 ] = end_point;
 
-            // make sure to set the start and end points so that we are
-            // incrementing upwards through rows
-            let row_start, row_end;
-            if (y_1 < y_2) {
-                row_start = y_1;
-                row_end = y_2;
-            } else {
-                row_start = y_2;
-                row_end = y_1;
-            }
+      let direction = Math.sign(y2 - y1);
+      let horizontal = y1 === y2;
+      let vertical = x1 === x2;
+
+      let edge_y = y1;
+
+      let edge_line = get_line_from_points(start_point, end_point);
+
+      let edge_ymin = Math.min(y1, y2);
+      let edge_ymax = Math.max(y1, y2);
+
+      logger.debug("\nedge", i, ":", edge);
+      logger.debug("direction:", direction);
+      logger.debug("horizontal:", horizontal);
+      logger.debug("vertical:", vertical);
+      logger.debug("edge_ymin:", edge_ymin);
+      logger.debug("edge_ymax:", edge_ymax);
+
+      let start_lng, start_lat, end_lat, end_lng;
+      if (x1 < x2) {
+        [ start_lng, start_lat ] = start_point;
+        [ end_lng, end_lat ] = end_point;
+      } else {
+        [ start_lng, start_lat ] = end_point;
+        [ end_lng, end_lat ]  = start_point;
+      }
 
 
-            row_start = force_within(row_start, 0, num_rows - 1);
-            row_end = force_within(row_end, 0, num_rows - 1);
+      if (start_lng === undefined) throw Error("start_lng is " + start_lng);
 
-            logger.debug("row_start:", row_start);
-            logger.debug("row_end:", row_end);
+      // find the y values in the image coordinate space
+      let y_1 = Math.round((lat_0 - .5*cell_height - start_lat ) / cell_height);
+      let y_2 = Math.round((lat_0 - .5*cell_height - end_lat) / cell_height);
 
-            // iterate through image lines within the change in y of
-            // the edge line and find all intersections
-            for (let j = row_start; j < row_end + 1; j++) {
-                let image_line = image_lines[j];
+      // make sure to set the start and end points so that we are
+      // incrementing upwards through rows
+      let row_start, row_end;
+      if (y_1 < y_2) {
+        row_start = y_1;
+        row_end = y_2;
+      } else {
+        row_start = y_2;
+        row_end = y_1;
+      }
 
 
-                if (image_line === undefined) {
-                    console.error("j:", j);
-                    console.error("image_lines:", image_lines);
-                    throw Error("image_lines");
-                }
+      row_start = force_within(row_start, 0, num_rows - 1);
+      row_end = force_within(row_end, 0, num_rows - 1);
 
-                // because you know x is zero in ax + by = c, so by = c and b = -1, so -1 * y = c or y = -1 * c
-                let image_line_y = -1 * image_line.c;
-                //if (j === row_start) console.log("image_line_y:", image_line_y);
+      logger.debug("row_start:", row_start);
+      logger.debug("row_end:", row_end);
 
-                let starts_on_line = y1 === image_line_y;
-                let ends_on_line = y2 === image_line_y;
-                let ends_off_line = !ends_on_line;
+      // iterate through image lines within the change in y of
+      // the edge line and find all intersections
+      for (let j = row_start; j < row_end + 1; j++) {
+        let image_line = image_lines[j];
 
-                let xmin_on_line, xmax_on_line;
-                if (horizontal) {
-                    //console.log("horizontal line:", edge_y);
-                    //console.log("image_line_:", image_line_y);
-                    if (edge_y === image_line_y) {
-                        //console.log("horizontal on line!:", edge_y);
-                        xmin_on_line = start_lng;
-                        xmax_on_line = end_lng;
-                    } else {
-                        continue; // stop running calculations for this horizontal line because it doesn't intersect at all
-                    }
-                } else if (vertical) {
-                    /* we have to have a seprate section for vertical bc of floating point arithmetic probs with get_inter..." */
-                    if (image_line_y >= edge_ymin && image_line_y <= edge_ymax) {
-                        xmin_on_line = start_lng;
-                        xmax_on_line = end_lng;
-                    }
-                } else if (starts_on_line) {
-                    // we know that the other end is not on the line because then it would be horizontal
-                    xmin_on_line = xmax_on_line = x1;
-                } else if (ends_on_line) {
-                    // we know that the other end is not on the line because then it would be horizontal
-                    xmin_on_line = xmax_on_line = x2;
-                } else {
-                    try {
-                        xmin_on_line = xmax_on_line = get_intersection_of_two_lines(edge_line, image_line).x;
-                    } catch (error) {
-                        logger.error('error getting intersection of two lines: ', error);
-                        logger.info("j:", j);
-                        logger.info("edge:", edge);
-                        logger.info("image_line_y:", image_line_y);
-                        logger.info("edge_line:", edge_line);
-                        logger.info("image_line:", image_line);
-                        logger.info("image_lines:", image_lines);
-                        throw error;
-                    }
-                }
 
-                // check to see if the intersection point is within the range of
-                // the edge line segment. If it is, add the intersection to the
-                // list of intersections at the corresponding index for that row
-                // in intersections_by_row
-                if (xmin_on_line && xmax_on_line && (horizontal || (xmin_on_line >= start_lng && xmax_on_line <= end_lng && image_line_y <= edge_ymax && image_line_y >= edge_ymin))) {
-                    //let image_pixel_index = Math.floor((intersection.x - lng_0) / cell_width);
-                    //intersections_by_row[j].push(image_pixel_index);
-                    intersections_by_row[j].push({
-                        direction,
-                        index: i,
-                        edge: edge,
-                        ends_on_line,
-                        ends_off_line,
-                        horizontal,
-                        starts_on_line,
-                        vertical,
-                        xmin: xmin_on_line,
-                        xmax: xmax_on_line,
-                        image_line_y
-                    });
-                }
-            }
+        if (image_line === undefined) {
+          console.error("j:", j);
+          console.error("image_lines:", image_lines);
+          throw Error("image_lines");
         }
 
-        logger.debug("intersections_by_row.length:", intersections_by_row.length);
+        // because you know x is zero in ax + by = c, so by = c and b = -1, so -1 * y = c or y = -1 * c
+        let image_line_y = -1 * image_line.c;
+        //if (j === row_start) console.log("image_line_y:", image_line_y);
+
+        let starts_on_line = y1 === image_line_y;
+        let ends_on_line = y2 === image_line_y;
+        let ends_off_line = !ends_on_line;
+
+        let xmin_on_line, xmax_on_line;
+        if (horizontal) {
+          //console.log("horizontal line:", edge_y);
+          //console.log("image_line_:", image_line_y);
+          if (edge_y === image_line_y) {
+            //console.log("horizontal on line!:", edge_y);
+            xmin_on_line = start_lng;
+            xmax_on_line = end_lng;
+          } else {
+            continue; // stop running calculations for this horizontal line because it doesn't intersect at all
+          }
+        } else if (vertical) {
+          /* we have to have a seprate section for vertical bc of floating point arithmetic probs with get_inter..." */
+          if (image_line_y >= edge_ymin && image_line_y <= edge_ymax) {
+            xmin_on_line = start_lng;
+            xmax_on_line = end_lng;
+          }
+        } else if (starts_on_line) {
+          // we know that the other end is not on the line because then it would be horizontal
+          xmin_on_line = xmax_on_line = x1;
+        } else if (ends_on_line) {
+          // we know that the other end is not on the line because then it would be horizontal
+          xmin_on_line = xmax_on_line = x2;
+        } else {
+          try {
+            xmin_on_line = xmax_on_line = get_intersection_of_two_lines(edge_line, image_line).x;
+          } catch (error) {
+            logger.error('error getting intersection of two lines: ', error);
+            logger.info("j:", j);
+            logger.info("edge:", edge);
+            logger.info("image_line_y:", image_line_y);
+            logger.info("edge_line:", edge_line);
+            logger.info("image_line:", image_line);
+            logger.info("image_lines:", image_lines);
+            throw error;
+          }
+        }
+
+        // check to see if the intersection point is within the range of
+        // the edge line segment. If it is, add the intersection to the
+        // list of intersections at the corresponding index for that row
+        // in intersections_by_row
+        if (xmin_on_line && xmax_on_line && (horizontal || (xmin_on_line >= start_lng && xmax_on_line <= end_lng && image_line_y <= edge_ymax && image_line_y >= edge_ymin))) {
+          //let image_pixel_index = Math.floor((intersection.x - lng_0) / cell_width);
+          //intersections_by_row[j].push(image_pixel_index);
+          intersections_by_row[j].push({
+            direction,
+            index: i,
+            edge: edge,
+            ends_on_line,
+            ends_off_line,
+            horizontal,
+            starts_on_line,
+            vertical,
+            xmin: xmin_on_line,
+            xmax: xmax_on_line,
+            image_line_y
+          });
+        }
+      }
+    }
+
+    logger.debug("intersections_by_row.length:", intersections_by_row.length);
 
 
-        let line_strings = [];
-        intersections_by_row.map((segments_in_row, row_index) => {
-            logger.debug(row_index, "segments_in_row.length:", segments_in_row.length);
-            if (segments_in_row.length > 0) {
-                //console.log("\n\nsegments in row:", segments_in_row);
-                let clusters = cluster_line_segments(segments_in_row, number_of_edges);
-                //console.log('clusters:', clusters);
-                let categorized = clusters.map(categorize_intersection);
-                //console.log("categorized:", categorized);
-                let [ throughs, nonthroughs ] = _.partition(categorized, item => item.through);
+    let line_strings = [];
+    intersections_by_row.map((segments_in_row, row_index) => {
+      logger.debug(row_index, "segments_in_row.length:", segments_in_row.length);
+      if (segments_in_row.length > 0) {
+        //console.log("\n\nsegments in row:", segments_in_row);
+        let clusters = cluster_line_segments(segments_in_row, number_of_edges);
+        //console.log('clusters:', clusters);
+        let categorized = clusters.map(categorize_intersection);
+        //console.log("categorized:", categorized);
+        let [ throughs, nonthroughs ] = _.partition(categorized, item => item.through);
 
-                if (throughs.length % 2 === 1) {
-                    logger.error('number of indexes for this row are incorrect, resolving as an odd number');
-                    logger.info("row_index:", row_index);
-                    logger.info("segments_in_row.length:", segments_in_row.length);
-                    logger.info("segments_in_row:", JSON.stringify(segments_in_row));
-                    logger.info("clusters.length:", clusters.length);
-                    logger.info("clusters:", clusters);
-                    logger.info("categorized:", categorized);
-                    throw Error("throughs.length for " + row_index + " is odd with " + throughs.length);
-                }
+        if (throughs.length % 2 === 1) {
+          logger.error('number of indexes for this row are incorrect, resolving as an odd number');
+          logger.info("row_index:", row_index);
+          logger.info("segments_in_row.length:", segments_in_row.length);
+          logger.info("segments_in_row:", JSON.stringify(segments_in_row));
+          logger.info("clusters.length:", clusters.length);
+          logger.info("clusters:", clusters);
+          logger.info("categorized:", categorized);
+          throw Error("throughs.length for " + row_index + " is odd with " + throughs.length);
+        }
 
-                //console.log("throughs:", throughs);
-                //console.log("nonthroughs:", nonthroughs);
-                let insides = nonthroughs.map(intersection => [intersection.xmin, intersection.xmax]);
-                //console.log("insides from nonthroughs:", insides);
+        //console.log("throughs:", throughs);
+        //console.log("nonthroughs:", nonthroughs);
+        let insides = nonthroughs.map(intersection => [intersection.xmin, intersection.xmax]);
+        //console.log("insides from nonthroughs:", insides);
 
-                throughs = _.sortBy(throughs, "xmin");
-                //console.log("sorted throughs", throughs);
+        throughs = _.sortBy(throughs, "xmin");
+        //console.log("sorted throughs", throughs);
 
-                let couples = couple(throughs).map(couple => {
-                    let [left, right] = couple;
-                    return [left.xmin, right.xmax];
-                });
-
-                insides = insides.concat(couples);
-
-                /*
-                    This makes sure we don't double count pixels.
-                    For example, converts `[[0,10],[10,10]]` to `[[0,10]]`
-                */
-                insides = merge_ranges(insides);
-
-
-                logger.debug(() => {
-                    insides.forEach(insidepair => {
-                        let [x1, x2] = insidepair;
-                        let y = segments_in_row[0].image_line_y;
-                        line_strings.push(turf_lineString([[x1, y], [x2, y]], {"stroke": "red", "stroke-width": 1,"stroke-opacity": 1}));
-                    });
-                });
-
-                insides.forEach(pair => {
-
-                    let [xmin, xmax] = pair;
-
-                    //convert left and right to image pixels
-                    let left = Math.round((xmin - (lng_0 + .5*cell_width)) / cell_width);
-                    let right = Math.round((xmax - (lng_0 + .5*cell_width)) / cell_width);
-
-                    let start_column_index = Math.max(left, 0);
-                    let end_column_index = Math.min(right, image_width);
-
-
-                    for (let column_index = start_column_index; column_index <= end_column_index; column_index++) {
-                        image_bands.forEach((band, band_index) => {
-                            var value = band[row_index][column_index];
-                            if (value != undefined && value !== no_data_value) {
-                                run_this_function_on_each_pixel_inside_geometry(value, band_index);
-                            }
-                        });
-                    }
-                });
-            }
+        let couples = couple(throughs).map(couple => {
+          let [left, right] = couple;
+          return [left.xmin, right.xmax];
         });
+
+        insides = insides.concat(couples);
+
+        /*
+          This makes sure we don't double count pixels.
+          For example, converts `[[0,10],[10,10]]` to `[[0,10]]`
+        */
+        insides = merge_ranges(insides);
+
 
         logger.debug(() => {
-            let fc = turf_featureCollection(line_strings);
-            //fs.writeFileSync("/tmp/lns" + edges_index + ".geojson", JSON.stringify(fc));
+          insides.forEach(insidepair => {
+            let [x1, x2] = insidepair;
+            let y = segments_in_row[0].image_line_y;
+            line_strings.push(turf_lineString([[x1, y], [x2, y]], {"stroke": "red", "stroke-width": 1,"stroke-opacity": 1}));
+          });
         });
+
+        insides.forEach(pair => {
+
+          let [xmin, xmax] = pair;
+
+          //convert left and right to image pixels
+          let left = Math.round((xmin - (lng_0 + .5*cell_width)) / cell_width);
+          let right = Math.round((xmax - (lng_0 + .5*cell_width)) / cell_width);
+
+          let start_column_index = Math.max(left, 0);
+          let end_column_index = Math.min(right, image_width);
+
+
+          for (let column_index = start_column_index; column_index <= end_column_index; column_index++) {
+            image_bands.forEach((band, band_index) => {
+              var value = band[row_index][column_index];
+              if (value != undefined && value !== no_data_value) {
+                run_this_function_on_each_pixel_inside_geometry(value, band_index);
+              }
+            });
+          }
+        });
+      }
     });
+
+    logger.debug(() => {
+      let fc = turf_featureCollection(line_strings);
+      //fs.writeFileSync("/tmp/lns" + edges_index + ".geojson", JSON.stringify(fc));
+    });
+  });
 }

--- a/packages/intersect-polygon/test.js
+++ b/packages/intersect-polygon/test.js
@@ -29,54 +29,54 @@ let turf_bbox = require("@turf/bbox");
 let turf_bboxPolygon = require("@turf/bbox-polygon");
 
 let test = () => {
-    describe("Testing intersection of simple geometries", function() {
-        describe("Testing intersection of box", function() {
-            it("Got correct count_of_values", function() {
-                this.timeout(1000000);
-                return load(url).then(georaster => {
+  describe("Testing intersection of simple geometries", function() {
+    describe("Testing intersection of box", function() {
+      it("Got correct count_of_values", function() {
+        this.timeout(1000000);
+        return load(url).then(georaster => {
 
-                    let expected_number_of_intersecting_pixels = 0;
-                    georaster.values.forEach(band => {
-                        band.forEach(row => {
-                            row.forEach(value => {
-                                if (value != georaster.no_data_value) {
-                                    expected_number_of_intersecting_pixels++;
-                                }
-                            });
-                        });
-                    });
-                    console.log("[test] expect_number_of_intersecting_pixels:", expected_number_of_intersecting_pixels);
-                    let pixelHeight = georaster.pixelHeight;
-                    let pixelWidth = georaster.pixelWidth;
-                    // minX, minY, maxX, maxY 
-                    let geom = turf_bboxPolygon([georaster.xmin + .5*pixelWidth, georaster.ymin + .5*pixelHeight, georaster.xmax - .5*pixelWidth, georaster.ymax - .5*pixelHeight]);
-                    console.log("[test] geom:", geom);
-                    let coordinates = utils.get_geojson_coors(geom);
-                    console.log("[test] coordinates:", coordinates);
-                    let number_of_intersecting_pixels = 0;
-                    intersect_polygon(georaster, coordinates, () => number_of_intersecting_pixels++);
-                    expect(number_of_intersecting_pixels).to.equal(expected_number_of_intersecting_pixels);
-                });
+          let expected_number_of_intersecting_pixels = 0;
+          georaster.values.forEach(band => {
+            band.forEach(row => {
+              row.forEach(value => {
+                if (value != georaster.no_data_value) {
+                  expected_number_of_intersecting_pixels++;
+                }
+              });
             });
+          });
+          console.log("[test] expect_number_of_intersecting_pixels:", expected_number_of_intersecting_pixels);
+          let pixelHeight = georaster.pixelHeight;
+          let pixelWidth = georaster.pixelWidth;
+          // minX, minY, maxX, maxY
+          let geom = turf_bboxPolygon([georaster.xmin + .5*pixelWidth, georaster.ymin + .5*pixelHeight, georaster.xmax - .5*pixelWidth, georaster.ymax - .5*pixelHeight]);
+          console.log("[test] geom:", geom);
+          let coordinates = utils.get_geojson_coors(geom);
+          console.log("[test] coordinates:", coordinates);
+          let number_of_intersecting_pixels = 0;
+          intersect_polygon(georaster, coordinates, () => number_of_intersecting_pixels++);
+          expect(number_of_intersecting_pixels).to.equal(expected_number_of_intersecting_pixels);
         });
+      });
     });
-    describe('Intersect Polygon (getting pixels in raster that intersect polygon)', function() {
-        describe("Test intersection calculations for Country with Multiple Rings", function() {
-            this.timeout(1000000);
-            it("Got correct sum", () => {
-                return load(url_to_data + "ghsl/tiles/GHS_POP_GPW42015_GLOBE_R2015A_54009_1k_v1_0_4326_30_40.tif").then(georaster => {
-                    return fetch(url_to_geojson)
-                    .then(response => response.json())
-                    .then(country => {
-                        let number_of_intersecting_pixels = 0;
-                        let geom = convert_geometry('polygon', country);
-                        intersect_polygon(georaster, geom, () => number_of_intersecting_pixels++);
-                        expect(number_of_intersecting_pixels).to.equal(281);
-                    });
-                });
-            });
+  });
+  describe('Intersect Polygon (getting pixels in raster that intersect polygon)', function() {
+    describe("Test intersection calculations for Country with Multiple Rings", function() {
+      this.timeout(1000000);
+      it("Got correct sum", () => {
+        return load(url_to_data + "ghsl/tiles/GHS_POP_GPW42015_GLOBE_R2015A_54009_1k_v1_0_4326_30_40.tif").then(georaster => {
+          return fetch(url_to_geojson)
+          .then(response => response.json())
+          .then(country => {
+            let number_of_intersecting_pixels = 0;
+            let geom = convert_geometry('polygon', country);
+            intersect_polygon(georaster, geom, () => number_of_intersecting_pixels++);
+            expect(number_of_intersecting_pixels).to.equal(281);
+          });
         });
-    })
+      });
+    });
+  })
 }
 
 test();

--- a/packages/load/load.js
+++ b/packages/load/load.js
@@ -10,45 +10,45 @@ let cache = require('../cache/cache');
 
 module.exports = (url_or_file) => (
 
-    new Promise((resolve, reject) => {
-        if (!in_browser && typeof url_or_file === 'object') {
-            throw `Direct raster loading is currently not supported outside of the browser
-                due to dependency limitations. Please use either a url or run the code 
-                in the browser.`
-        }
+  new Promise((resolve, reject) => {
+    if (!in_browser && typeof url_or_file === 'object') {
+      throw `Direct raster loading is currently not supported outside of the browser
+        due to dependency limitations. Please use either a url or run the code
+        in the browser.`
+    }
 
-        let url = typeof url_or_file === 'object' ? URL.createObjectURL(url_or_file) : url_or_file;
-        //console.log("url:", url);
+    let url = typeof url_or_file === 'object' ? URL.createObjectURL(url_or_file) : url_or_file;
+    //console.log("url:", url);
 
-        if (cache[url]) {
-            resolve(cache[url]);
-        } else {
-            fetch(url).then(
-                response => in_browser ? response.arrayBuffer() : response.buffer() ,
-                error => {
-                    let domain = new URL(url).host;
-                    let error_message = `Gio could not get the file from ${domain}.  
-                        This is often because a website's security prevents cross domain requests.  
-                        Download the file and load it manually.`;
-                    console.error(error_message);
-                    reject(error_message);
-                }
-            ).then(b => {
-                //console.log("b:", b);
-                if (b) {
-                    let array_buffer;
-                    if (in_browser) {
-                        array_buffer = b;
-                    } else {
-                        array_buffer = b.buffer.slice(b.byteOffset, b.byteOffset + b.byteLength);
-                    }
-                    parse_georaster(array_buffer).then(georaster => {
-                        cache[url] = georaster;
-                        //console.log("resolving:", georaster);
-                        resolve(georaster);
-                    });
-                }
-            });
+    if (cache[url]) {
+      resolve(cache[url]);
+    } else {
+      fetch(url).then(
+        response => in_browser ? response.arrayBuffer() : response.buffer() ,
+        error => {
+          let domain = new URL(url).host;
+          let error_message = `Gio could not get the file from ${domain}.
+            This is often because a website's security prevents cross domain requests.
+            Download the file and load it manually.`;
+          console.error(error_message);
+          reject(error_message);
         }
-    })
+      ).then(b => {
+        //console.log("b:", b);
+        if (b) {
+          let array_buffer;
+          if (in_browser) {
+            array_buffer = b;
+          } else {
+            array_buffer = b.buffer.slice(b.byteOffset, b.byteOffset + b.byteLength);
+          }
+          parse_georaster(array_buffer).then(georaster => {
+            cache[url] = georaster;
+            //console.log("resolving:", georaster);
+            resolve(georaster);
+          });
+        }
+      });
+    }
+  })
 );

--- a/packages/load/load.js
+++ b/packages/load/load.js
@@ -1,10 +1,14 @@
 'use strict';
 
-let parse_georaster = require("georaster");
+const parse_georaster = require("georaster");
 
-let in_browser = typeof window === 'object';
+const in_browser = typeof window === 'object';
 var fetch = in_browser ? window.fetch : require('node-fetch');
 var URL = in_browser ? window.URL : require("url").parse;
+
+const error_load_file_outside_browser = require('../../constants').ERROR_LOAD_FILE_OUTSIDE_BROSWER;
+const error_bad_url = require('../../constants').ERROR_BAD_URL;
+const error_parsing_geotiff = require('../../constants').ERROR_PARSING_GEOTIFF;
 
 let cache = require('../cache/cache');
 
@@ -12,41 +16,35 @@ module.exports = (url_or_file) => (
 
   new Promise((resolve, reject) => {
     if (!in_browser && typeof url_or_file === 'object') {
-      throw `Direct raster loading is currently not supported outside of the browser
-        due to dependency limitations. Please use either a url or run the code
-        in the browser.`
+      reject(new Error(error_load_file_outside_browser));
     }
 
-    let url = typeof url_or_file === 'object' ? URL.createObjectURL(url_or_file) : url_or_file;
-    //console.log("url:", url);
+    const url = typeof url_or_file === 'object' ? URL.createObjectURL(url_or_file) : url_or_file;
 
     if (cache[url]) {
       resolve(cache[url]);
     } else {
-      fetch(url).then(
-        response => in_browser ? response.arrayBuffer() : response.buffer() ,
-        error => {
-          let domain = new URL(url).host;
-          let error_message = `Gio could not get the file from ${domain}.
-            This is often because a website's security prevents cross domain requests.
-            Download the file and load it manually.`;
-          console.error(error_message);
-          reject(error_message);
-        }
-      ).then(b => {
-        //console.log("b:", b);
-        if (b) {
-          let array_buffer;
-          if (in_browser) {
-            array_buffer = b;
-          } else {
-            array_buffer = b.buffer.slice(b.byteOffset, b.byteOffset + b.byteLength);
+      fetch(url).then(response => {
+        if (response.ok) return in_browser ? response.arrayBuffer() : response.buffer()
+
+        const domain = new URL(url).host;
+        reject(new Error(error_bad_url));
+      }).then(b => {
+        try {
+          if (b) {
+            let array_buffer;
+            if (in_browser) {
+              array_buffer = b;
+            } else {
+              array_buffer = b.buffer.slice(b.byteOffset, b.byteOffset + b.byteLength);
+            }
+            parse_georaster(array_buffer).then(georaster => {
+              cache[url] = georaster;
+              resolve(georaster);
+            });
           }
-          parse_georaster(array_buffer).then(georaster => {
-            cache[url] = georaster;
-            //console.log("resolving:", georaster);
-            resolve(georaster);
-          });
+        } catch (e) {
+          reject(new Error(error_parsing_geotiff));
         }
       });
     }

--- a/packages/load/test.js
+++ b/packages/load/test.js
@@ -1,21 +1,24 @@
 'use strict';
 
-let expect = require('chai').expect;
+const expect = require('chai').expect;
 
-let fetch = require('node-fetch');
+const fetch = require('node-fetch');
 
-let load = require('./load');
+const load = require('./load');
 
-let path = 'http://localhost:3000/data/test.tiff';
+const path = 'http://localhost:3000/data/test.tiff';
+const incorrect_path = 'http://localhost:3000/data/this-is-not-a-real-dataset.tiff';
 
-let properties = [
+const error_bad_url = require('../../constants').ERROR_BAD_URL;
+
+const properties = [
   'projection',
   'xmin',
   'values'
 ];
 
-let test = () => (
-  describe('Gio Load Feature', function() {
+const test = () => (
+  describe('Geoblaze Load Feature', function() {
     describe('Load from URL', function() {
       this.timeout(1000000);
       it('Loaded tiff file', () => {
@@ -23,6 +26,15 @@ let test = () => (
           properties.forEach(property => {
             expect(georaster).to.have.property(property);
           });
+        });
+      });
+    });
+
+    describe('Error from invalid URL', function() {
+      this.timeout(1000000);
+      it('Loaded tiff file', () => {
+        return load(incorrect_path).then(null, error => {
+          expect(error.message).to.equal(error_bad_url);
         });
       });
     });

--- a/packages/load/test.js
+++ b/packages/load/test.js
@@ -9,38 +9,38 @@ let load = require('./load');
 let path = 'http://localhost:3000/data/test.tiff';
 
 let properties = [
-    'projection',
-    'xmin',
-    'values'
+  'projection',
+  'xmin',
+  'values'
 ];
 
 let test = () => (
-    describe('Gio Load Feature', function() {
-        describe('Load from URL', function() {
-            this.timeout(1000000);
-            it('Loaded tiff file', () => {
-                return load(path).then(georaster => {
-                    properties.forEach(property => {
-                        expect(georaster).to.have.property(property);
-                    });
-                });
-            });
+  describe('Gio Load Feature', function() {
+    describe('Load from URL', function() {
+      this.timeout(1000000);
+      it('Loaded tiff file', () => {
+        return load(path).then(georaster => {
+          properties.forEach(property => {
+            expect(georaster).to.have.property(property);
+          });
         });
+      });
+    });
 
-        // describe('Load from File', function() {
-        //  this.timeout(1000000);
-        //  it('Loaded tiff file', () => {
-        //      return fetch(path).then(image => {
-        //          return load(blob).then(tiff => {
-        //              let image = tiff.getImage();
-        //              properties.forEach(property => {
-        //                  expect(image).to.have.property(property);
-        //              })
-        //          });
-        //      });
-        //  })
-        // })
-    })
+    // describe('Load from File', function() {
+    //  this.timeout(1000000);
+    //  it('Loaded tiff file', () => {
+    //    return fetch(path).then(image => {
+    //      return load(blob).then(tiff => {
+    //        let image = tiff.getImage();
+    //        properties.forEach(property => {
+    //          expect(image).to.have.property(property);
+    //        })
+    //      });
+    //    });
+    //  })
+    // })
+  })
 )
 
 test();

--- a/packages/max/max.js
+++ b/packages/max/max.js
@@ -7,28 +7,28 @@ let intersect_polygon = require('../intersect-polygon/intersect-polygon');
 let _ = require("underscore");
 
 let get_max = (values, no_data_value) => {
-    let number_of_values = values.length;
-    if (number_of_values > 0) {
-        let max = null;
-        for (let i = 0; i < number_of_values; i++) {
-            let value = values[i];
-            if (value !== no_data_value) {
+  let number_of_values = values.length;
+  if (number_of_values > 0) {
+    let max = null;
+    for (let i = 0; i < number_of_values; i++) {
+      let value = values[i];
+      if (value !== no_data_value) {
 
-                /* We first compare the current value to the stored maximum.
-                If the new value is greater than the stored minimum, replace the
-                stored minimum with the new value. When checking a greater than
-                comparison aganist a null value, like in the first comparison,
-                the statement resolves as true. */
-            
-                if (value > max) {
-                    max = value;
-                }
-            }
+        /* We first compare the current value to the stored maximum.
+        If the new value is greater than the stored minimum, replace the
+        stored minimum with the new value. When checking a greater than
+        comparison aganist a null value, like in the first comparison,
+        the statement resolves as true. */
+
+        if (value > max) {
+          max = value;
         }
-        return max;
-    } else {
-        throw 'No values were provided';
+      }
     }
+    return max;
+  } else {
+    throw 'No values were provided';
+  }
 }
 
 /**
@@ -44,48 +44,48 @@ let get_max = (values, no_data_value) => {
  * var maxs = geoblaze.max(georaster, geometry);
  */
 function get_max_for_raster(georaster, geom) {
-    
-    try {
 
-        let no_data_value = georaster.no_data_value;
+  try {
 
-        if (geom === null || geom === undefined) {
+    let no_data_value = georaster.no_data_value;
 
-            return georaster.values.map(band => {
-                return _.max(band.map(row => get_max(row, no_data_value)));
-            });
-        
-        } else if (utils.is_bbox(geom)) {
-            geom = convert_geometry('bbox', geom);
+    if (geom === null || geom === undefined) {
 
-            // grab array of values;
-            let flat = true;
-            let values = get(georaster, geom, flat);
+      return georaster.values.map(band => {
+        return _.max(band.map(row => get_max(row, no_data_value)));
+      });
 
-            // get max value
-            return values.map(band => get_max(band, no_data_value));
-            
-        } else if (utils.is_polygon(geom)) {
-            geom = convert_geometry('polygon', geom);
-            let values = [];
+    } else if (utils.is_bbox(geom)) {
+      geom = convert_geometry('bbox', geom);
 
-            intersect_polygon(georaster, geom, (value, band_index) => {
-                if (!values[band_index]) {
-                    values[band_index] = value; 
-                } else if (value > values[band_index]) {
-                    values[band_index] = value; 
-                }
-            });
+      // grab array of values;
+      let flat = true;
+      let values = get(georaster, geom, flat);
 
-            if (values) return values;
-            else throw 'No Values were found in the given geometry';
+      // get max value
+      return values.map(band => get_max(band, no_data_value));
 
-        } else {
-            throw 'Non-Bounding Box geometries are currently not supported.'
-        }   
-    } catch(e) {
-        console.error(e);
-        throw e;
+    } else if (utils.is_polygon(geom)) {
+      geom = convert_geometry('polygon', geom);
+      let values = [];
+
+      intersect_polygon(georaster, geom, (value, band_index) => {
+        if (!values[band_index]) {
+          values[band_index] = value;
+        } else if (value > values[band_index]) {
+          values[band_index] = value;
+        }
+      });
+
+      if (values) return values;
+      else throw 'No Values were found in the given geometry';
+
+    } else {
+      throw 'Non-Bounding Box geometries are currently not supported.'
     }
+  } catch(e) {
+    console.error(e);
+    throw e;
+  }
 }
 module.exports = get_max_for_raster;

--- a/packages/max/test.js
+++ b/packages/max/test.js
@@ -18,7 +18,7 @@ let polygon = [[
 let expected_polygon_value = 7807.40;
 
 let test = () => {
-  describe('Gio Max Feature', function() {
+  describe('Geoblaze Max Feature', function() {
     describe('Get Max from Bounding Box', function() {
       this.timeout(1000000);
       it('Got Correct Value', () => {

--- a/packages/max/test.js
+++ b/packages/max/test.js
@@ -10,43 +10,43 @@ let bbox = [80.63, 7.42, 84.21, 10.10];
 let expected_bbox_value = 5166.70;
 
 let polygon = [[
-    [83.12255859375, 22.49225722008518], [82.96875, 21.57571893245848], [81.58447265624999,  1.207458730482642],
-    [83.07861328125, 20.34462694382967], [83.8037109375,  19.497664168139053], [84.814453125, 19.766703551716976],
-    [85.078125, 21.166483858206583], [86.044921875, 20.838277806058933], [86.98974609375, 22.49225722008518],
-    [85.58349609375, 24.54712317973075], [84.6826171875, 23.36242859340884], [83.12255859375, 22.49225722008518]
+  [83.12255859375, 22.49225722008518], [82.96875, 21.57571893245848], [81.58447265624999,  1.207458730482642],
+  [83.07861328125, 20.34462694382967], [83.8037109375,  19.497664168139053], [84.814453125, 19.766703551716976],
+  [85.078125, 21.166483858206583], [86.044921875, 20.838277806058933], [86.98974609375, 22.49225722008518],
+  [85.58349609375, 24.54712317973075], [84.6826171875, 23.36242859340884], [83.12255859375, 22.49225722008518]
 ]];
 let expected_polygon_value = 7807.40;
 
 let test = () => {
-    describe('Gio Max Feature', function() {
-        describe('Get Max from Bounding Box', function() {
-            this.timeout(1000000);
-            it('Got Correct Value', () => {
-                return load(url).then(georaster => {
-                    let value = Number(max(georaster, bbox)[0].toFixed(2));
-                    expect(value).to.equal(expected_bbox_value);
-                });
-            });
+  describe('Gio Max Feature', function() {
+    describe('Get Max from Bounding Box', function() {
+      this.timeout(1000000);
+      it('Got Correct Value', () => {
+        return load(url).then(georaster => {
+          let value = Number(max(georaster, bbox)[0].toFixed(2));
+          expect(value).to.equal(expected_bbox_value);
         });
-        describe('Get Max from Polygon', function() {
-            this.timeout(1000000);
-            it('Got Correct Value', () => {
-                return load(url).then(georaster => {
-                    let value = Number(max(georaster, polygon)[0].toFixed(2));
-                    expect(value).to.equal(expected_polygon_value);
-                });
-            });
+      });
+    });
+    describe('Get Max from Polygon', function() {
+      this.timeout(1000000);
+      it('Got Correct Value', () => {
+        return load(url).then(georaster => {
+          let value = Number(max(georaster, polygon)[0].toFixed(2));
+          expect(value).to.equal(expected_polygon_value);
         });
-        describe('Get Max from Raster without polygon', function() {
-            this.timeout(1000000);
-            it('Got Correct Value', () => {
-                return load(url).then(georaster => {
-                    let value = max(georaster)[0];
-                    expect(value).to.equal(8131.2);
-                });
-            });
+      });
+    });
+    describe('Get Max from Raster without polygon', function() {
+      this.timeout(1000000);
+      it('Got Correct Value', () => {
+        return load(url).then(georaster => {
+          let value = max(georaster)[0];
+          expect(value).to.equal(8131.2);
         });
-    })
+      });
+    });
+  })
 }
 
 test();

--- a/packages/mean/mean.js
+++ b/packages/mean/mean.js
@@ -8,71 +8,71 @@ let convert_geometry = require('../convert-geometry/convert-geometry');
 let intersect_polygon = require('../intersect-polygon/intersect-polygon');
 
 module.exports = (georaster, geom) => {
-    
-    try {
 
-        if (utils.is_bbox(geom)) { // if geometry is a bounding box
-            geom = convert_geometry('bbox', geom);
-            let no_data_value = georaster.no_data_value;
+  try {
 
-            // grab array of values
-            let values = get(georaster, geom);
+    if (utils.is_bbox(geom)) { // if geometry is a bounding box
+      geom = convert_geometry('bbox', geom);
+      let no_data_value = georaster.no_data_value;
 
-            // sum values
-            let sums = []
-            for (let band_index = 0; band_index < values.length; band_index++) {
-                let running_sum_for_band = 0;
-                let number_of_cells_with_values_in_band = 0;
-                let band = values[band_index];
-                let number_of_rows = band.length;
-                for (let row_index = 0; row_index < number_of_rows; row_index++) {
-                    let row = band[row_index];
-                    let number_of_cells = row.length;
-                    for (let column_index = 0; column_index < number_of_cells; column_index++) {
-                        let value = row[column_index];
-                        if (value !== no_data_value) {
-                            number_of_cells_with_values_in_band++;
-                            running_sum_for_band += value;
-                        }
-                    }
-                }
-                sums.push(running_sum_for_band / number_of_cells_with_values_in_band);
+      // grab array of values
+      let values = get(georaster, geom);
+
+      // sum values
+      let sums = []
+      for (let band_index = 0; band_index < values.length; band_index++) {
+        let running_sum_for_band = 0;
+        let number_of_cells_with_values_in_band = 0;
+        let band = values[band_index];
+        let number_of_rows = band.length;
+        for (let row_index = 0; row_index < number_of_rows; row_index++) {
+          let row = band[row_index];
+          let number_of_cells = row.length;
+          for (let column_index = 0; column_index < number_of_cells; column_index++) {
+            let value = row[column_index];
+            if (value !== no_data_value) {
+              number_of_cells_with_values_in_band++;
+              running_sum_for_band += value;
             }
-            return sums;
-        } else if (utils.is_polygon(geom)) { // if geometry is a polygon
-            geom = convert_geometry('polygon', geom);
-            let sums = [];
-            let num_values = [];
-            
-            // the third argument of intersect_polygon is a function which
-            // is run on every value, we use it to increment the sum so we
-            // can later divide it by the total value count to get the mean
-            intersect_polygon(georaster, geom, (value, band_index) => {
-                if (num_values[band_index]) {
-                    sums[band_index] += value; 
-                    num_values[band_index] += 1;
-                } else {
-                    sums[band_index] = value;
-                    num_values[band_index] = 1;
-                }
-            });
+          }
+        }
+        sums.push(running_sum_for_band / number_of_cells_with_values_in_band);
+      }
+      return sums;
+    } else if (utils.is_polygon(geom)) { // if geometry is a polygon
+      geom = convert_geometry('polygon', geom);
+      let sums = [];
+      let num_values = [];
 
-            // here we check to see how many bands were in the image
-            // based on the sums and use that to select how we display
-            // the result
-            let results = [];
-            num_values.forEach((num, index) => {
-                if (num > 0) results.push(sums[index] / num);
-            });
-
-            if (results) return results;
-            else throw 'No Values were found in the given geometry';
-
+      // the third argument of intersect_polygon is a function which
+      // is run on every value, we use it to increment the sum so we
+      // can later divide it by the total value count to get the mean
+      intersect_polygon(georaster, geom, (value, band_index) => {
+        if (num_values[band_index]) {
+          sums[band_index] += value;
+          num_values[band_index] += 1;
         } else {
-            throw 'Only Bounding Box and Polygon geometries are currently supported.'
-        }   
-    } catch(e) {
-        console.error(e);
-        throw e;
+          sums[band_index] = value;
+          num_values[band_index] = 1;
+        }
+      });
+
+      // here we check to see how many bands were in the image
+      // based on the sums and use that to select how we display
+      // the result
+      let results = [];
+      num_values.forEach((num, index) => {
+        if (num > 0) results.push(sums[index] / num);
+      });
+
+      if (results) return results;
+      else throw 'No Values were found in the given geometry';
+
+    } else {
+      throw 'Only Bounding Box and Polygon geometries are currently supported.'
     }
+  } catch(e) {
+    console.error(e);
+    throw e;
+  }
 }

--- a/packages/mean/test.js
+++ b/packages/mean/test.js
@@ -40,7 +40,7 @@ let polygon_geojson = `{
 let expected_polygon_geojson_value = 1826.74 ;
 
 let test = () => {
-  describe('Gio Mean Feature', function() {
+  describe('Geoblaze Mean Feature', function() {
     describe('Get Mean from Bounding Box', function() {
       this.timeout(1000000);
       it('Got Correct Value', () => {

--- a/packages/mean/test.js
+++ b/packages/mean/test.js
@@ -10,65 +10,65 @@ let bbox = [80.63, 7.42, 84.21, 10.10];
 let expected_bbox_value = 1232.47;
 
 let polygon = [[
-    [83.12255859375, 22.49225722008518], [82.96875, 21.57571893245848], [81.58447265624999,  1.207458730482642],
-    [83.07861328125, 20.34462694382967], [83.8037109375,  19.497664168139053], [84.814453125, 19.766703551716976],
-    [85.078125, 21.166483858206583], [86.044921875, 20.838277806058933], [86.98974609375, 22.49225722008518],
-    [85.58349609375, 24.54712317973075], [84.6826171875, 23.36242859340884], [83.12255859375, 22.49225722008518]
+  [83.12255859375, 22.49225722008518], [82.96875, 21.57571893245848], [81.58447265624999,  1.207458730482642],
+  [83.07861328125, 20.34462694382967], [83.8037109375,  19.497664168139053], [84.814453125, 19.766703551716976],
+  [85.078125, 21.166483858206583], [86.044921875, 20.838277806058933], [86.98974609375, 22.49225722008518],
+  [85.58349609375, 24.54712317973075], [84.6826171875, 23.36242859340884], [83.12255859375, 22.49225722008518]
 ]];
 let expected_polygon_value = 1826.74;
 
-let polygon_geojson = `{ 
-    "type": "FeatureCollection",
-    "features": [
-        { "type": "Feature",
-            "geometry": {
-                "type": "Polygon",
-                "coordinates": [[
-                    [83.12255859375, 22.49225722008518], [82.96875, 21.57571893245848], [81.58447265624999,  1.207458730482642],
-                    [83.07861328125, 20.34462694382967], [83.8037109375,  19.497664168139053], [84.814453125, 19.766703551716976],
-                    [85.078125, 21.166483858206583], [86.044921875, 20.838277806058933], [86.98974609375, 22.49225722008518],
-                    [85.58349609375, 24.54712317973075], [84.6826171875, 23.36242859340884], [83.12255859375, 22.49225722008518]
-                ]]
-            },
-            "properties": {
-                "prop0": "value0",
-                "prop1": {"this": "that"}
-            }
-         }
-    ]
+let polygon_geojson = `{
+  "type": "FeatureCollection",
+  "features": [
+    { "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+          [83.12255859375, 22.49225722008518], [82.96875, 21.57571893245848], [81.58447265624999,  1.207458730482642],
+          [83.07861328125, 20.34462694382967], [83.8037109375,  19.497664168139053], [84.814453125, 19.766703551716976],
+          [85.078125, 21.166483858206583], [86.044921875, 20.838277806058933], [86.98974609375, 22.49225722008518],
+          [85.58349609375, 24.54712317973075], [84.6826171875, 23.36242859340884], [83.12255859375, 22.49225722008518]
+        ]]
+      },
+      "properties": {
+        "prop0": "value0",
+        "prop1": {"this": "that"}
+      }
+     }
+  ]
 }`
 let expected_polygon_geojson_value = 1826.74 ;
 
 let test = () => {
-    describe('Gio Mean Feature', function() {
-        describe('Get Mean from Bounding Box', function() {
-            this.timeout(1000000);
-            it('Got Correct Value', () => {
-                return load(url).then(georaster => {
-                    let value = Number(mean(georaster, bbox)[0].toFixed(2));
-                    expect(value).to.equal(expected_bbox_value);
-                });
-            });
+  describe('Gio Mean Feature', function() {
+    describe('Get Mean from Bounding Box', function() {
+      this.timeout(1000000);
+      it('Got Correct Value', () => {
+        return load(url).then(georaster => {
+          let value = Number(mean(georaster, bbox)[0].toFixed(2));
+          expect(value).to.equal(expected_bbox_value);
         });
-        describe('Get Mean from Polygon', function() {
-            this.timeout(1000000);
-            it('Got Correct Value', () => {
-                return load(url).then(georaster => {
-                    let value = Number(mean(georaster, polygon)[0].toFixed(2));
-                    expect(value).to.equal(expected_polygon_value);
-                })
-            })
-        });
-        describe('Get Mean from Polygon (GeoJSON)', function() {
-            this.timeout(1000000);
-            it('Got Correct Value', () => {
-                return load(url).then(georaster => {
-                    let value = Number(mean(georaster, polygon_geojson)[0].toFixed(2));
-                    expect(value).to.equal(expected_polygon_geojson_value);
-                })
-            })
+      });
+    });
+    describe('Get Mean from Polygon', function() {
+      this.timeout(1000000);
+      it('Got Correct Value', () => {
+        return load(url).then(georaster => {
+          let value = Number(mean(georaster, polygon)[0].toFixed(2));
+          expect(value).to.equal(expected_polygon_value);
         })
+      })
+    });
+    describe('Get Mean from Polygon (GeoJSON)', function() {
+      this.timeout(1000000);
+      it('Got Correct Value', () => {
+        return load(url).then(georaster => {
+          let value = Number(mean(georaster, polygon_geojson)[0].toFixed(2));
+          expect(value).to.equal(expected_polygon_geojson_value);
+        })
+      })
     })
+  })
 }
 
 test();

--- a/packages/median/median.js
+++ b/packages/median/median.js
@@ -8,18 +8,18 @@ let _ = require("underscore");
 
 let get_median = values => {
 
-    // sort values
-    values.sort();
-    let values_length = values.length;
+  // sort values
+  values.sort();
+  let values_length = values.length;
 
-    // pull middle value from sorted array
-    if (values_length % 2 !== 0) {
-        let middle = Math.floor(values_length / 2);
-        return values[middle];
-    } else {
-        let middle = values_length / 2;
-        return (values[middle - 1] + values[middle]) / 2;
-    }
+  // pull middle value from sorted array
+  if (values_length % 2 !== 0) {
+    let middle = Math.floor(values_length / 2);
+    return values[middle];
+  } else {
+    let middle = values_length / 2;
+    return (values[middle - 1] + values[middle]) / 2;
+  }
 }
 
 /**
@@ -35,74 +35,74 @@ let get_median = values => {
  * var medians = geoblaze.median(georaster, geometry);
  */
 function get_median_for_raster(georaster, geom) {
-    
-    try {
 
-        let geom_is_bbox = utils.is_bbox(geom);
-        
-        if (geom === null || geom === undefined || geom_is_bbox) {
+  try {
 
-            if (geom_is_bbox) {
+    let geom_is_bbox = utils.is_bbox(geom);
 
-                geom = convert_geometry('bbox', geom);
+    if (geom === null || geom === undefined || geom_is_bbox) {
 
-            }
+      if (geom_is_bbox) {
 
-            let values = get(georaster, geom);
+        geom = convert_geometry('bbox', geom);
 
-            let no_data_value = georaster.no_data_value;
+      }
 
-            // median values
-            let medians = []
-            for (let band_index = 0; band_index < values.length; band_index++) {
-                let band = values[band_index];
-                let counts = utils.count_values_in_table(band, no_data_value);
-                let number_of_cells_with_values_in_band = utils.sum(_.values(counts));
-                let sorted_counts = _.pairs(counts).sort((pair1, pair2) => Number(pair1[0]) - Number(pair2[0]));
-                //console.log("sorted_counts:", sorted_counts);
-                let middle = number_of_cells_with_values_in_band / 2;
-                let running_count = 0;
-                for (let i = 0; i < sorted_counts.length; i++) {
-                    let sorted_count = sorted_counts[i];
-                    let value = Number(sorted_count[0]);
-                    let count = sorted_count[1];
-                    running_count += count;
-                    if (running_count > middle) {
-                        medians.push(value);
-                        break;
-                    } else if (running_count === middle) {
-                        medians.push((value + Number(sorted_counts[i+1])) / 2);
-                        break;
-                    }
-                }
-                //console.log("medians:", medians);
-            }
-            return medians;
+      let values = get(georaster, geom);
 
-        } else if (utils.is_polygon(geom)) {
-            geom = convert_geometry('polygon', geom);
-            let values = [];
+      let no_data_value = georaster.no_data_value;
 
-            // the third argument of this function is a function which
-            // runs for every pixel in the polygon. Here we add them to
-            // an array to run through the get_median function
-            intersect_polygon(georaster, geom, (value, band_index) => {
-                if (values[band_index]) {
-                    values[band_index].push(value);
-                } else {
-                    values[band_index] = [value];
-                }
-            });
+      // median values
+      let medians = []
+      for (let band_index = 0; band_index < values.length; band_index++) {
+        let band = values[band_index];
+        let counts = utils.count_values_in_table(band, no_data_value);
+        let number_of_cells_with_values_in_band = utils.sum(_.values(counts));
+        let sorted_counts = _.pairs(counts).sort((pair1, pair2) => Number(pair1[0]) - Number(pair2[0]));
+        //console.log("sorted_counts:", sorted_counts);
+        let middle = number_of_cells_with_values_in_band / 2;
+        let running_count = 0;
+        for (let i = 0; i < sorted_counts.length; i++) {
+          let sorted_count = sorted_counts[i];
+          let value = Number(sorted_count[0]);
+          let count = sorted_count[1];
+          running_count += count;
+          if (running_count > middle) {
+            medians.push(value);
+            break;
+          } else if (running_count === middle) {
+            medians.push((value + Number(sorted_counts[i+1])) / 2);
+            break;
+          }
+        }
+        //console.log("medians:", medians);
+      }
+      return medians;
 
-            if (values.length > 0) return values.map(get_median);
-            else throw 'No Values were found in the given geometry';
+    } else if (utils.is_polygon(geom)) {
+      geom = convert_geometry('polygon', geom);
+      let values = [];
 
+      // the third argument of this function is a function which
+      // runs for every pixel in the polygon. Here we add them to
+      // an array to run through the get_median function
+      intersect_polygon(georaster, geom, (value, band_index) => {
+        if (values[band_index]) {
+          values[band_index].push(value);
         } else {
-            throw 'Non-Bounding Box geometries are currently not supported.'
-        }   
-    } catch(e) {
-        console.error(e);
-        throw e;
+          values[band_index] = [value];
+        }
+      });
+
+      if (values.length > 0) return values.map(get_median);
+      else throw 'No Values were found in the given geometry';
+
+    } else {
+      throw 'Non-Bounding Box geometries are currently not supported.'
     }
+  } catch(e) {
+    console.error(e);
+    throw e;
+  }
 }
 module.exports = get_median_for_raster;

--- a/packages/median/test.js
+++ b/packages/median/test.js
@@ -35,7 +35,7 @@ let polygon = [[
 let expected_polygon_value = 2750.5;
 
 let test = () => {
-  describe('Gio Median Feature', function() {
+  describe('Geoblaze Median Feature', function() {
     describe('Get Median from Bounding Box', function() {
       this.timeout(1000000);
       it('Got Correct Value', () => {

--- a/packages/median/test.js
+++ b/packages/median/test.js
@@ -10,70 +10,70 @@ let bbox = [80.63, 7.42, 84.21, 10.10];
 let expected_bbox_value = 906.70;
 
 let bbox_geojson = `{
-    "type": "FeatureCollection",
-    "features": [{
-        "type": "Feature",
-        "properties": {},
-        "geometry": {
-            "type": "Polygon",
-            "coordinates": [[
-                [83.583984375, 19.89072302399691], [86.1328125, 19.89072302399691], 
-                [86.1328125, 21.69826549685252], [83.583984375, 21.69826549685252], 
-                [83.583984375, 19.89072302399691]
-            ]]
-        }
-    }]
+  "type": "FeatureCollection",
+  "features": [{
+    "type": "Feature",
+    "properties": {},
+    "geometry": {
+      "type": "Polygon",
+      "coordinates": [[
+        [83.583984375, 19.89072302399691], [86.1328125, 19.89072302399691],
+        [86.1328125, 21.69826549685252], [83.583984375, 21.69826549685252],
+        [83.583984375, 19.89072302399691]
+      ]]
+    }
+  }]
 }`;
 let expected_bbox_geojson_value = 1849.4;
 
 let polygon = [[
-    [83.12255859375, 22.49225722008518], [82.96875, 21.57571893245848], [81.58447265624999,  1.207458730482642],
-    [83.07861328125, 20.34462694382967], [83.8037109375,  19.497664168139053], [84.814453125, 19.766703551716976],
-    [85.078125, 21.166483858206583], [86.044921875, 20.838277806058933], [86.98974609375, 22.49225722008518],
-    [85.58349609375, 24.54712317973075], [84.6826171875, 23.36242859340884], [83.12255859375, 22.49225722008518]
+  [83.12255859375, 22.49225722008518], [82.96875, 21.57571893245848], [81.58447265624999,  1.207458730482642],
+  [83.07861328125, 20.34462694382967], [83.8037109375,  19.497664168139053], [84.814453125, 19.766703551716976],
+  [85.078125, 21.166483858206583], [86.044921875, 20.838277806058933], [86.98974609375, 22.49225722008518],
+  [85.58349609375, 24.54712317973075], [84.6826171875, 23.36242859340884], [83.12255859375, 22.49225722008518]
 ]];
 let expected_polygon_value = 2750.5;
 
 let test = () => {
-    describe('Gio Median Feature', function() {
-        describe('Get Median from Bounding Box', function() {
-            this.timeout(1000000);
-            it('Got Correct Value', () => {
-                return load(url).then(georaster => {
-                    let value = Number(median(georaster, bbox)[0].toFixed(2));
-                    expect(value).to.equal(expected_bbox_value);
-                });
-            });
+  describe('Gio Median Feature', function() {
+    describe('Get Median from Bounding Box', function() {
+      this.timeout(1000000);
+      it('Got Correct Value', () => {
+        return load(url).then(georaster => {
+          let value = Number(median(georaster, bbox)[0].toFixed(2));
+          expect(value).to.equal(expected_bbox_value);
         });
-        describe('Get Median from Bounding Box (GeoJSON)', function() {
-            this.timeout(1000000);
-            it('Got Correct Value', () => {
-                return load(url).then(georaster => {
-                    let value = Number(median(georaster, bbox_geojson)[0].toFixed(2));
-                    expect(value).to.equal(expected_bbox_geojson_value);
-                });
-            });
+      });
+    });
+    describe('Get Median from Bounding Box (GeoJSON)', function() {
+      this.timeout(1000000);
+      it('Got Correct Value', () => {
+        return load(url).then(georaster => {
+          let value = Number(median(georaster, bbox_geojson)[0].toFixed(2));
+          expect(value).to.equal(expected_bbox_geojson_value);
         });
-        describe('Get Median from Polygon', function() {
-            this.timeout(1000000);
-            it('Got Correct Value', () => {
-                return load(url).then(georaster => {
-                    let value = Number(median(georaster, polygon)[0].toFixed(2));
-                    expect(value).to.equal(expected_polygon_value);
-                });
-            });
+      });
+    });
+    describe('Get Median from Polygon', function() {
+      this.timeout(1000000);
+      it('Got Correct Value', () => {
+        return load(url).then(georaster => {
+          let value = Number(median(georaster, polygon)[0].toFixed(2));
+          expect(value).to.equal(expected_polygon_value);
         });
-        describe('Get Median from Whole Raster', function() {
-            this.timeout(1000000);
-            it('Got Correct Value', () => {
-                return load(url).then(georaster => {
-                    let value = median(georaster)[0];
-                    expect(value).to.equal(0);
-                });
-            });
+      });
+    });
+    describe('Get Median from Whole Raster', function() {
+      this.timeout(1000000);
+      it('Got Correct Value', () => {
+        return load(url).then(georaster => {
+          let value = median(georaster)[0];
+          expect(value).to.equal(0);
         });
- 
-    })
+      });
+    });
+
+  })
 }
 
 test();

--- a/packages/min/min.js
+++ b/packages/min/min.js
@@ -7,28 +7,28 @@ let intersect_polygon = require('../intersect-polygon/intersect-polygon');
 let _ = require("underscore");
 
 let get_min = (values, no_data_value) => {
-    let number_of_values = values.length;
-    if (number_of_values > 0) {
-        let min = null;
-        for (let i = 0; i < number_of_values; i++) {
-            let value = values[i];
-            if (value !== no_data_value) {
+  let number_of_values = values.length;
+  if (number_of_values > 0) {
+    let min = null;
+    for (let i = 0; i < number_of_values; i++) {
+      let value = values[i];
+      if (value !== no_data_value) {
 
-                /* We first compare the current value to the stored minimum.
-                If the new value is less than the stored minimum, replace the
-                stored minimum with the new value. Also check to see
-                if the minimum value has not yet been defined, and 
-                define it as the current value if that is the case. */
+        /* We first compare the current value to the stored minimum.
+        If the new value is less than the stored minimum, replace the
+        stored minimum with the new value. Also check to see
+        if the minimum value has not yet been defined, and
+        define it as the current value if that is the case. */
 
-                if (value < min || min === null) {
-                    min = value;
-                }
-            }
+        if (value < min || min === null) {
+          min = value;
         }
-        return min;
-    } else {
-        throw 'No values were provided';
+      }
     }
+    return min;
+  } else {
+    throw 'No values were provided';
+  }
 }
 
 /**
@@ -44,48 +44,48 @@ let get_min = (values, no_data_value) => {
  * var mins = geoblaze.min(georaster, geometry);
  */
 function get_min_for_raster(georaster, geom) {
-    
-    try {
 
-        let no_data_value = georaster.no_data_value;
+  try {
 
-        if (geom === null || geom === undefined) {
+    let no_data_value = georaster.no_data_value;
 
-            return georaster.values.map(band => {
-                return _.min(band.map(row => get_min(row, no_data_value)).filter(value => value !== undefined && value !== null));
-            });
+    if (geom === null || geom === undefined) {
 
-        } else if (utils.is_bbox(geom)) {
-            geom = convert_geometry('bbox', geom);
+      return georaster.values.map(band => {
+        return _.min(band.map(row => get_min(row, no_data_value)).filter(value => value !== undefined && value !== null));
+      });
 
-            // grab array of values;
-            let values = get(georaster, geom, true);
+    } else if (utils.is_bbox(geom)) {
+      geom = convert_geometry('bbox', geom);
 
-            // get min value
-            return values.map(band => get_min(band, no_data_value));
-            
-        
-        } else if (utils.is_polygon(geom)) {
-            geom = convert_geometry('polygon', geom);
-            let values = [];
+      // grab array of values;
+      let values = get(georaster, geom, true);
 
-            intersect_polygon(georaster, geom, (value, band_index) => {
-                if (typeof values[band_index] === 'undefined') {
-                    values[band_index] = value; 
-                } else if (value < values[band_index]) {
-                    values[band_index] = value; 
-                }
-            });
+      // get min value
+      return values.map(band => get_min(band, no_data_value));
 
-            if (values.length > 0) return values;
-            else throw 'No Values were found in the given geometry';
 
-        } else {
-            throw 'Non-Bounding Box geometries are currently not supported.'
-        }   
-    } catch(e) {
-        console.error(e);
-        throw e;
+    } else if (utils.is_polygon(geom)) {
+      geom = convert_geometry('polygon', geom);
+      let values = [];
+
+      intersect_polygon(georaster, geom, (value, band_index) => {
+        if (typeof values[band_index] === 'undefined') {
+          values[band_index] = value;
+        } else if (value < values[band_index]) {
+          values[band_index] = value;
+        }
+      });
+
+      if (values.length > 0) return values;
+      else throw 'No Values were found in the given geometry';
+
+    } else {
+      throw 'Non-Bounding Box geometries are currently not supported.'
     }
+  } catch(e) {
+    console.error(e);
+    throw e;
+  }
 }
 module.exports = get_min_for_raster;

--- a/packages/min/test.js
+++ b/packages/min/test.js
@@ -9,44 +9,44 @@ let bbox = [80.63, 7.42, 84.21, 10.10];
 let expected_bbox_value = 0;
 
 let polygon = [[
-    [83.12255859375, 22.49225722008518], [82.96875, 21.57571893245848], [81.58447265624999,  1.207458730482642],
-    [83.07861328125, 20.34462694382967], [83.8037109375,  19.497664168139053], [84.814453125, 19.766703551716976],
-    [85.078125, 21.166483858206583], [86.044921875, 20.838277806058933], [86.98974609375, 22.49225722008518],
-    [85.58349609375, 24.54712317973075], [84.6826171875, 23.36242859340884], [83.12255859375, 22.49225722008518]
+  [83.12255859375, 22.49225722008518], [82.96875, 21.57571893245848], [81.58447265624999,  1.207458730482642],
+  [83.07861328125, 20.34462694382967], [83.8037109375,  19.497664168139053], [84.814453125, 19.766703551716976],
+  [85.078125, 21.166483858206583], [86.044921875, 20.838277806058933], [86.98974609375, 22.49225722008518],
+  [85.58349609375, 24.54712317973075], [84.6826171875, 23.36242859340884], [83.12255859375, 22.49225722008518]
 ]];
 let expected_polygon_value = 0;
 
 let test = () => {
-    describe('Gio Min Feature', function() {
-        describe('Get Min from Bounding Box', function() {
-            this.timeout(1000000);
-            it('Got Correct Value', () => {
-                return load(url).then(georaster => {
-                    let value = Number(min(georaster, bbox)[0].toFixed(2));
-                    expect(value).to.equal(expected_bbox_value);
-                });
-            });
+  describe('Gio Min Feature', function() {
+    describe('Get Min from Bounding Box', function() {
+      this.timeout(1000000);
+      it('Got Correct Value', () => {
+        return load(url).then(georaster => {
+          let value = Number(min(georaster, bbox)[0].toFixed(2));
+          expect(value).to.equal(expected_bbox_value);
         });
-        describe('Get Min from Polygon', function() {
-            this.timeout(1000000);
-            it('Got Correct Value', () => {
-                return load(url).then(georaster => {
-                    let value = Number(min(georaster, polygon)[0].toFixed(2));
-                    expect(value).to.equal(expected_polygon_value);
-                });
-            });
+      });
+    });
+    describe('Get Min from Polygon', function() {
+      this.timeout(1000000);
+      it('Got Correct Value', () => {
+        return load(url).then(georaster => {
+          let value = Number(min(georaster, polygon)[0].toFixed(2));
+          expect(value).to.equal(expected_polygon_value);
         });
-        describe('Get Min from whole Raster', function() {
-            this.timeout(1000000);
-            it('Got Correct Value', () => {
-                return load(url).then(georaster => {
-                    let value = min(georaster)[0];
-                    expect(value).to.equal(expected_polygon_value);
-                });
-            });
+      });
+    });
+    describe('Get Min from whole Raster', function() {
+      this.timeout(1000000);
+      it('Got Correct Value', () => {
+        return load(url).then(georaster => {
+          let value = min(georaster)[0];
+          expect(value).to.equal(expected_polygon_value);
         });
- 
-    })
+      });
+    });
+
+  })
 }
 
 test();

--- a/packages/min/test.js
+++ b/packages/min/test.js
@@ -17,7 +17,7 @@ let polygon = [[
 let expected_polygon_value = 0;
 
 let test = () => {
-  describe('Gio Min Feature', function() {
+  describe('Geoblaze Min Feature', function() {
     describe('Get Min from Bounding Box', function() {
       this.timeout(1000000);
       it('Got Correct Value', () => {

--- a/packages/mode/mode.js
+++ b/packages/mode/mode.js
@@ -8,18 +8,18 @@ let convert_geometry = require('../convert-geometry/convert-geometry');
 let intersect_polygon = require('../intersect-polygon/intersect-polygon');
 
 let get_mode_from_counts_object = counts => {
-    // iterate through values to get highest frequency
-    let buckets = _.sortBy(_.pairs(counts), pair => pair[1])
-    let max_frequency = buckets[buckets.length - 1][1];
-    let modes = buckets
-        .filter(pair => pair[1] === max_frequency)
-        .map(pair => Number(pair[0]));
-    return modes.length === 1 ? modes[0] : modes; 
+  // iterate through values to get highest frequency
+  let buckets = _.sortBy(_.pairs(counts), pair => pair[1])
+  let max_frequency = buckets[buckets.length - 1][1];
+  let modes = buckets
+    .filter(pair => pair[1] === max_frequency)
+    .map(pair => Number(pair[0]));
+  return modes.length === 1 ? modes[0] : modes;
 }
 
 let get_mode = values => {
-    let counts = _.countBy(values);
-    return get_mode_from_counts_object(counts);
+  let counts = _.countBy(values);
+  return get_mode_from_counts_object(counts);
 }
 
 
@@ -36,56 +36,56 @@ let get_mode = values => {
  * var modes = geoblaze.mode(georaster, geometry);
  */
 function get_modes_for_raster(georaster, geom) {
-    
-    try {
 
-        let no_data_value = georaster.no_data_value;
+  try {
 
-        if (geom === null || geom === undefined) {
+    let no_data_value = georaster.no_data_value;
 
-            let modes_for_all_bands = georaster.values.map(band => {
-                let counts = utils.count_values_in_table(band, no_data_value);
-                return get_mode_from_counts_object(counts);
-            });
-            return modes_for_all_bands.length === 1 ? modes_for_all_bands[0] : modes_for_all_bands; 
-        
-        } else if (utils.is_bbox(geom)) {
+    if (geom === null || geom === undefined) {
 
-            geom = convert_geometry('bbox', geom);
+      let modes_for_all_bands = georaster.values.map(band => {
+        let counts = utils.count_values_in_table(band, no_data_value);
+        return get_mode_from_counts_object(counts);
+      });
+      return modes_for_all_bands.length === 1 ? modes_for_all_bands[0] : modes_for_all_bands;
 
-            // grab array of values;
-            let flat = true;
-            let values = get(georaster, geom, flat);
+    } else if (utils.is_bbox(geom)) {
 
-            return values
-                .map(band => band.filter(value => value !== no_data_value))
-                .map(get_mode);
+      geom = convert_geometry('bbox', geom);
 
-        } else if (utils.is_polygon(geom)) {
-            geom = convert_geometry('polygon', geom);
-            let values = [];
+      // grab array of values;
+      let flat = true;
+      let values = get(georaster, geom, flat);
 
-            // the third argument of this function is a function which
-            // runs for every pixel in the polygon. Here we add them to
-            // an array to run through the get_mode function
-            intersect_polygon(georaster, geom, (value, band_index) => {
-                if (values[band_index]) {
-                    values[band_index].push(value);
-                } else {
-                    values[band_index] = [value];
-                }
-            });
+      return values
+        .map(band => band.filter(value => value !== no_data_value))
+        .map(get_mode);
 
-            if (values.length > 0) return values.map(get_mode);
-            else throw 'No Values were found in the given geometry';
+    } else if (utils.is_polygon(geom)) {
+      geom = convert_geometry('polygon', geom);
+      let values = [];
 
+      // the third argument of this function is a function which
+      // runs for every pixel in the polygon. Here we add them to
+      // an array to run through the get_mode function
+      intersect_polygon(georaster, geom, (value, band_index) => {
+        if (values[band_index]) {
+          values[band_index].push(value);
         } else {
-            throw 'Non-Bounding Box geometries are currently not supported.'
-        }  
-    } catch(e) {
-        console.error(e);
-        throw e;
+          values[band_index] = [value];
+        }
+      });
+
+      if (values.length > 0) return values.map(get_mode);
+      else throw 'No Values were found in the given geometry';
+
+    } else {
+      throw 'Non-Bounding Box geometries are currently not supported.'
     }
+  } catch(e) {
+    console.error(e);
+    throw e;
+  }
 
 }
 module.exports = get_modes_for_raster;

--- a/packages/mode/test.js
+++ b/packages/mode/test.js
@@ -18,7 +18,7 @@ let polygon = [[
 let expected_polygon_value = 0;
 
 let test = () => {
-  describe('Gio Mode Feature', function() {
+  describe('Geoblaze Mode Feature', function() {
     describe('Get Mode from Bounding Box', function() {
       this.timeout(1000000);
       it('Got Correct Value', () => {

--- a/packages/mode/test.js
+++ b/packages/mode/test.js
@@ -10,44 +10,44 @@ let bbox = [80.63, 7.42, 84.21, 10.10];
 let expected_bbox_value = 0;
 
 let polygon = [[
-    [83.12255859375, 22.49225722008518], [82.96875, 21.57571893245848], [81.58447265624999,  1.207458730482642],
-    [83.07861328125, 20.34462694382967], [83.8037109375,  19.497664168139053], [84.814453125, 19.766703551716976],
-    [85.078125, 21.166483858206583], [86.044921875, 20.838277806058933], [86.98974609375, 22.49225722008518],
-    [85.58349609375, 24.54712317973075], [84.6826171875, 23.36242859340884], [83.12255859375, 22.49225722008518]
+  [83.12255859375, 22.49225722008518], [82.96875, 21.57571893245848], [81.58447265624999,  1.207458730482642],
+  [83.07861328125, 20.34462694382967], [83.8037109375,  19.497664168139053], [84.814453125, 19.766703551716976],
+  [85.078125, 21.166483858206583], [86.044921875, 20.838277806058933], [86.98974609375, 22.49225722008518],
+  [85.58349609375, 24.54712317973075], [84.6826171875, 23.36242859340884], [83.12255859375, 22.49225722008518]
 ]];
 let expected_polygon_value = 0;
 
 let test = () => {
-    describe('Gio Mode Feature', function() {
-        describe('Get Mode from Bounding Box', function() {
-            this.timeout(1000000);
-            it('Got Correct Value', () => {
-                return load(url).then(georaster => {
-                    let value = mode(georaster, bbox)[0];
-                    expect(value).to.equal(expected_bbox_value);
-                });
-            });
+  describe('Gio Mode Feature', function() {
+    describe('Get Mode from Bounding Box', function() {
+      this.timeout(1000000);
+      it('Got Correct Value', () => {
+        return load(url).then(georaster => {
+          let value = mode(georaster, bbox)[0];
+          expect(value).to.equal(expected_bbox_value);
         });
-        describe('Get Mode from Polygon', function() {
-            this.timeout(1000000);
-            it('Got Correct Value', () => {
-                return load(url).then(georaster => {
-                    let value = mode(georaster, polygon)[0];
-                    expect(value).to.equal(expected_polygon_value);
-                });
-            });
+      });
+    });
+    describe('Get Mode from Polygon', function() {
+      this.timeout(1000000);
+      it('Got Correct Value', () => {
+        return load(url).then(georaster => {
+          let value = mode(georaster, polygon)[0];
+          expect(value).to.equal(expected_polygon_value);
         });
-        describe('Get Mode for whole raster', function() {
-            this.timeout(1000000);
-            it('Got Correct Value', () => {
-                return load(url).then(georaster => {
-                    let value = mode(georaster);
-                    expect(value).to.equal(expected_polygon_value);
-                });
-            });
+      });
+    });
+    describe('Get Mode for whole raster', function() {
+      this.timeout(1000000);
+      it('Got Correct Value', () => {
+        return load(url).then(georaster => {
+          let value = mode(georaster);
+          expect(value).to.equal(expected_polygon_value);
         });
- 
-    })
+      });
+    });
+
+  })
 }
 
 test();

--- a/packages/project/project.js
+++ b/packages/project/project.js
@@ -4,10 +4,10 @@ let proj4 = require('proj4');
 
 module.exports = {
 
-    get_projection(image) {
-        let geoKeys = image.getGeoKeys();
+  get_projection(image) {
+    let geoKeys = image.getGeoKeys();
 
 
-    }
+  }
 
 }

--- a/packages/sum/sum.js
+++ b/packages/sum/sum.js
@@ -18,63 +18,63 @@ let intersect_polygon = require('../intersect-polygon/intersect-polygon');
  * var sums = geoblaze.sum(georaster, geometry);
  */
 function sum(georaster, geom, test, debug=false) {
-    
-    try {
-        
-        if (geom === null || geom === undefined) {
 
-            let no_data_value = georaster.no_data_value;
-            return georaster.values.map(band => { // iterate over each band which include rows of pixels
-                return band.reduce((sum_of_band, row) => { // reduce all the rows into one sum
-                    return sum_of_band + row.reduce((sum_of_row, cell_value) => { // reduce each row to a sum of its pixel values
-                        return cell_value !== no_data_value && (test === undefined || test(cell_value)) ? sum_of_row + cell_value : sum_of_row;
-                    }, 0);
-                }, 0);
-            });
+  try {
 
-        } else if (utils.is_bbox(geom)) {
-            geom = convert_geometry('bbox', geom);
+    if (geom === null || geom === undefined) {
 
-            let values = get(georaster, geom);
-            let height = georaster.height;
-            let width = georaster.width;
-            let no_data_value = georaster.no_data_value;
+      let no_data_value = georaster.no_data_value;
+      return georaster.values.map(band => { // iterate over each band which include rows of pixels
+        return band.reduce((sum_of_band, row) => { // reduce all the rows into one sum
+          return sum_of_band + row.reduce((sum_of_row, cell_value) => { // reduce each row to a sum of its pixel values
+            return cell_value !== no_data_value && (test === undefined || test(cell_value)) ? sum_of_row + cell_value : sum_of_row;
+          }, 0);
+        }, 0);
+      });
 
-            // sum values
-            return values.map(band => { // iterate over each band which include rows of pixels
-                return band.reduce((sum_of_band, row) => { // reduce all the rows into one sum
-                    return sum_of_band + row.reduce((sum_of_row, cell_value) => { // reduce each row to a sum of its pixel values
-                        return cell_value !== no_data_value && (test === undefined || test(cell_value)) ? sum_of_row + cell_value : sum_of_row;
-                    }, 0);
-                }, 0);
-            });
+    } else if (utils.is_bbox(geom)) {
+      geom = convert_geometry('bbox', geom);
 
-        } else if (utils.is_polygon(geom, debug)) {
-            geom = convert_geometry('polygon', geom);
-            let sums = [];
-            
-            // the third argument of intersect_polygon is a function which
-            // is run on every value, we use it to increment the sum 
-            intersect_polygon(georaster, geom, (value, band_index) => {
-                if (test === undefined || test(value)) { 
-                    if (sums[band_index]) {
-                        sums[band_index] += value; 
-                    } else {
-                        sums[band_index] = value;
-                    }
-                }
-            });
+      let values = get(georaster, geom);
+      let height = georaster.height;
+      let width = georaster.width;
+      let no_data_value = georaster.no_data_value;
 
-            if (sums.length > 0) return sums;
-            else return [0];
-            
-        } else {
-            throw "Sum couldn't identify geometry"
-        }            
-    } catch(e) {
-        console.error(e);
-        throw e;
+      // sum values
+      return values.map(band => { // iterate over each band which include rows of pixels
+        return band.reduce((sum_of_band, row) => { // reduce all the rows into one sum
+          return sum_of_band + row.reduce((sum_of_row, cell_value) => { // reduce each row to a sum of its pixel values
+            return cell_value !== no_data_value && (test === undefined || test(cell_value)) ? sum_of_row + cell_value : sum_of_row;
+          }, 0);
+        }, 0);
+      });
+
+    } else if (utils.is_polygon(geom, debug)) {
+      geom = convert_geometry('polygon', geom);
+      let sums = [];
+
+      // the third argument of intersect_polygon is a function which
+      // is run on every value, we use it to increment the sum
+      intersect_polygon(georaster, geom, (value, band_index) => {
+        if (test === undefined || test(value)) {
+          if (sums[band_index]) {
+            sums[band_index] += value;
+          } else {
+            sums[band_index] = value;
+          }
+        }
+      });
+
+      if (sums.length > 0) return sums;
+      else return [0];
+
+    } else {
+      throw "Sum couldn't identify geometry"
     }
+  } catch(e) {
+    console.error(e);
+    throw e;
+  }
 }
 
 module.exports = sum

--- a/packages/sum/test.js
+++ b/packages/sum/test.js
@@ -218,7 +218,7 @@ let polygon_geojson_collection = `{
 let expected_polygon_geojson_collection_value = expected_polygon_geojson_value_1 + expected_polygon_geojson_value_2;
 
 let test = () => {
-  describe('Gio Sum Feature', function() {
+  describe('Geoblaze Sum Feature', function() {
     describe('Get Sum', function() {
       this.timeout(1000000);
       it('Got Correct Value', () => {

--- a/packages/sum/test.js
+++ b/packages/sum/test.js
@@ -31,10 +31,10 @@ let bbox = [80.63, 7.42, 84.21, 10.10];
 let expected_bbox_value = 262516.50;
 
 let polygon = [[
-    [83.12255859375, 22.49225722008518], [82.96875, 21.57571893245848], [81.58447265624999,  1.207458730482642],
-    [83.07861328125, 20.34462694382967], [83.8037109375,  19.497664168139053], [84.814453125, 19.766703551716976],
-    [85.078125, 21.166483858206583], [86.044921875, 20.838277806058933], [86.98974609375, 22.49225722008518],
-    [85.58349609375, 24.54712317973075], [84.6826171875, 23.36242859340884], [83.12255859375, 22.49225722008518]
+  [83.12255859375, 22.49225722008518], [82.96875, 21.57571893245848], [81.58447265624999,  1.207458730482642],
+  [83.07861328125, 20.34462694382967], [83.8037109375,  19.497664168139053], [84.814453125, 19.766703551716976],
+  [85.078125, 21.166483858206583], [86.044921875, 20.838277806058933], [86.98974609375, 22.49225722008518],
+  [85.58349609375, 24.54712317973075], [84.6826171875, 23.36242859340884], [83.12255859375, 22.49225722008518]
 ]];
 let expected_polygon_value = 3165731.9;
 
@@ -42,45 +42,45 @@ let expected_polygon_value = 3165731.9;
 let polygon_geojson_1 = `{
   "type": "FeatureCollection",
   "features": [
-    {
-      "type": "Feature",
-      "properties": {},
-      "geometry": {
-        "type": "Polygon",
-        "coordinates": [
-          [
-            [
-              86.220703125,
-              22.156883186860703
-            ],
-            [
-              86.341552734375,
-              21.43261686447735
-            ],
-            [
-              86.912841796875,
-              21.70847301324597
-            ],
-            [
-              87.000732421875,
-              22.39071391683855
-            ],
-            [
-              85.968017578125,
-              22.49225722008518
-            ],
-            [
-              85.726318359375,
-              21.912470952680266
-            ],
-            [
-              86.220703125,
-              22.156883186860703
-            ]
-          ]
-        ]
-      }
-    }]
+  {
+    "type": "Feature",
+    "properties": {},
+    "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+      [
+        86.220703125,
+        22.156883186860703
+      ],
+      [
+        86.341552734375,
+        21.43261686447735
+      ],
+      [
+        86.912841796875,
+        21.70847301324597
+      ],
+      [
+        87.000732421875,
+        22.39071391683855
+      ],
+      [
+        85.968017578125,
+        22.49225722008518
+      ],
+      [
+        85.726318359375,
+        21.912470952680266
+      ],
+      [
+        86.220703125,
+        22.156883186860703
+      ]
+      ]
+    ]
+    }
+  }]
 }`;
 
 let expected_polygon_geojson_value_1 = 320113.1;
@@ -88,45 +88,45 @@ let expected_polygon_geojson_value_1 = 320113.1;
 let polygon_geojson_2 = `{
   "type": "FeatureCollection",
   "features": [
-    {
-      "type": "Feature",
-      "properties": {},
-      "geometry": {
-        "type": "Polygon",
-        "coordinates": [
-          [
-            [
-              85.869140625,
-              20.64306554672647
-            ],
-            [
-              86.12182617187499,
-              21.022982546427425
-            ],
-            [
-              85.330810546875,
-              21.361013117950915
-            ],
-            [
-              84.44091796875,
-              21.3303150734318
-            ],
-            [
-              85.594482421875,
-              21.074248926792812
-            ],
-            [
-              85.067138671875,
-              20.715015145512087
-            ],
-            [
-              85.869140625,
-              20.64306554672647
-            ]
-          ]
-        ]
-      }
-    }]
+  {
+    "type": "Feature",
+    "properties": {},
+    "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+      [
+        85.869140625,
+        20.64306554672647
+      ],
+      [
+        86.12182617187499,
+        21.022982546427425
+      ],
+      [
+        85.330810546875,
+        21.361013117950915
+      ],
+      [
+        84.44091796875,
+        21.3303150734318
+      ],
+      [
+        85.594482421875,
+        21.074248926792812
+      ],
+      [
+        85.067138671875,
+        20.715015145512087
+      ],
+      [
+        85.869140625,
+        20.64306554672647
+      ]
+      ]
+    ]
+    }
+  }]
 }`;
 
 let expected_polygon_geojson_value_2 = 141335.5;
@@ -134,302 +134,302 @@ let expected_polygon_geojson_value_2 = 141335.5;
 let polygon_geojson_collection = `{
   "type": "FeatureCollection",
   "features": [
-    {
-      "type": "Feature",
-      "properties": {},
-      "geometry": {
-        "type": "Polygon",
-        "coordinates": [
-          [
-            [
-              86.220703125,
-              22.156883186860703
-            ],
-            [
-              86.341552734375,
-              21.43261686447735
-            ],
-            [
-              86.912841796875,
-              21.70847301324597
-            ],
-            [
-              87.000732421875,
-              22.39071391683855
-            ],
-            [
-              85.968017578125,
-              22.49225722008518
-            ],
-            [
-              85.726318359375,
-              21.912470952680266
-            ],
-            [
-              86.220703125,
-              22.156883186860703
-            ]
-          ]
-        ]
-      }
-    },
-    {
-      "type": "Feature",
-      "properties": {},
-      "geometry": {
-        "type": "Polygon",
-        "coordinates": [
-          [
-            [
-              85.869140625,
-              20.64306554672647
-            ],
-            [
-              86.12182617187499,
-              21.022982546427425
-            ],
-            [
-              85.330810546875,
-              21.361013117950915
-            ],
-            [
-              84.44091796875,
-              21.3303150734318
-            ],
-            [
-              85.594482421875,
-              21.074248926792812
-            ],
-            [
-              85.067138671875,
-              20.715015145512087
-            ],
-            [
-              85.869140625,
-              20.64306554672647
-            ]
-          ]
-        ]
-      }
+  {
+    "type": "Feature",
+    "properties": {},
+    "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+      [
+        86.220703125,
+        22.156883186860703
+      ],
+      [
+        86.341552734375,
+        21.43261686447735
+      ],
+      [
+        86.912841796875,
+        21.70847301324597
+      ],
+      [
+        87.000732421875,
+        22.39071391683855
+      ],
+      [
+        85.968017578125,
+        22.49225722008518
+      ],
+      [
+        85.726318359375,
+        21.912470952680266
+      ],
+      [
+        86.220703125,
+        22.156883186860703
+      ]
+      ]
+    ]
     }
+  },
+  {
+    "type": "Feature",
+    "properties": {},
+    "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+      [
+        85.869140625,
+        20.64306554672647
+      ],
+      [
+        86.12182617187499,
+        21.022982546427425
+      ],
+      [
+        85.330810546875,
+        21.361013117950915
+      ],
+      [
+        84.44091796875,
+        21.3303150734318
+      ],
+      [
+        85.594482421875,
+        21.074248926792812
+      ],
+      [
+        85.067138671875,
+        20.715015145512087
+      ],
+      [
+        85.869140625,
+        20.64306554672647
+      ]
+      ]
+    ]
+    }
+  }
   ]
 }`;
 
 let expected_polygon_geojson_collection_value = expected_polygon_geojson_value_1 + expected_polygon_geojson_value_2;
 
 let test = () => {
-    describe('Gio Sum Feature', function() {
-        describe('Get Sum', function() {
-            this.timeout(1000000);
-            it('Got Correct Value', () => {
-                return load(url).then(georaster => {
-                    let actual_value = Number(sum(georaster)[0].toFixed(2));
-                    let expected_value = 108343045.4;
-                    expect(actual_value).to.equal(expected_value);
-                });
-            });
+  describe('Gio Sum Feature', function() {
+    describe('Get Sum', function() {
+      this.timeout(1000000);
+      it('Got Correct Value', () => {
+        return load(url).then(georaster => {
+          let actual_value = Number(sum(georaster)[0].toFixed(2));
+          let expected_value = 108343045.4;
+          expect(actual_value).to.equal(expected_value);
         });
-        describe('Get Sum from Bounding Box', function() {
-            this.timeout(1000000);
-            it('Got Correct Value', () => {
-                return load(url).then(georaster => {
-                    let value = Number(sum(georaster, bbox)[0].toFixed(2));
-                    expect(value).to.equal(expected_bbox_value);
-                });
-            });
-        });
-        describe('Get Sum from Bounding Box Greater Then Raster', function() {
-            this.timeout(1000000);
-            it('Got Correct Value', () => {
-                return load(url_rwanda).then(georaster => {
-                    let value_with_buffered_bbox = Number(sum(georaster, bbox_rwanda)[0].toFixed(2));
-                    let value_without_bbox = Number(sum(georaster)[0].toFixed(2));
-                    expect(value_with_buffered_bbox).to.equal(104848.45);
-                    expect(value_without_bbox).to.equal(104848.45);
-                    expect(value_with_buffered_bbox).to.equal(value_without_bbox);
-                });
-            });
-        });
-        describe('Get Same Sum from GeoJSON and ESRI JSON', function() {
-            this.timeout(1000000);
-            it('Got Matching Value', () => {
-                let url_to_raster = url_to_data + "mapspam/spam2005v3r2_harvested-area_wheat_total.tiff";
-                return load(url_to_raster).then(georaster => {
-                    let country_names = ["Afghanistan", "Ukraine"];
-                    let promises = country_names.map(name => {
-                        return fetch_jsons([url_to_geojsons + name + ".geojson", url_to_arcgis_jsons + name + ".json"], true)
-                        .then(jsons => {
-                            let [geojson, arcgis_json] = jsons;
-                            let value_via_geojson = Number(sum(georaster, geojson)[0].toFixed(2));
-                            let value_via_arcgis_json = Number(sum(georaster, arcgis_json)[0].toFixed(2));
-                            let value_via_arcgis_json_polygon = Number(sum(georaster, arcgis_json.geometry)[0].toFixed(2));
-                            console.log("value_via_arcgis_json:", value_via_arcgis_json);
-                            expect(value_via_geojson).to.equal(value_via_arcgis_json);
-                            expect(value_via_geojson).to.equal(value_via_arcgis_json_polygon);
-                        });
-                    });
-                    return Promise.all(promises);
-                });
-            });
-        });
-        describe('Get Sum from Polygon', function() {
-            this.timeout(1000000);
-            it('Got Correct Value', () => {
-                return load(url).then(georaster => {
-                    let value = Number(sum(georaster, polygon)[0].toFixed(2));
-                    expect(value).to.equal(expected_polygon_value);
-                });
-            });
-        });
-        describe('Get Sum from Polygon (GeoJSON) 1', function() {
-            this.timeout(1000000);
-            it('Got Correct Value', () => {
-                return load(url).then(georaster => {
-                    let value = Number(sum(georaster, polygon_geojson_1)[0].toFixed(2));
-                    expect(value).to.equal(expected_polygon_geojson_value_1);
-                });
-            });
-        });
-        describe('Get Sum from Polygon (GeoJSON) 2', function() {
-            this.timeout(1000000);
-            it('Got Correct Value', () => {
-                return load(url).then(georaster => {
-                    let value = Number(sum(georaster, polygon_geojson_2)[0].toFixed(2));
-                    expect(value).to.equal(expected_polygon_geojson_value_2);
-                });
-            });
-        });
-        describe('Get Sum from Polygon (Multi-Polygon GeoJSON, 1 + 2)', function() {
-            this.timeout(1000000);
-            it('Got Correct Value', () => {
-                return load(url).then(georaster => {
-                    let value = Number(sum(georaster, polygon_geojson_collection)[0].toFixed(2));
-                    expect(value).to.equal(expected_polygon_geojson_collection_value);
-                });
-            });
-        });
-        describe("Test sum for Country with Multiple Rings", function() {
-            this.timeout(1000000);
-            it("Got correct sum", () => {
-                return load(url).then(georaster => {
-                    return utils.fetch_json(url_to_geojsons + "Akrotiri and Dhekelia.geojson")
-                    .then(country => {
-                        let value = sum(georaster, country);
-                        console.log("value:", value);
-                    });
-                });
-            });
-        });
-        describe('Get Sum from Polygon Above X Value', function() {
-            this.timeout(1000000);
-            it('Got Correct Value', () => {
-                return load(url).then(georaster => {
-                    let value = Number(sum(georaster, polygon, v => v > 3000)[0].toFixed(2));
-                    expect(value).to.equal(1501820.8);
-                });
-            });
-        });
-        describe("Test Super Simplified Albanian Polygon", function() {
-            it("Finish calculation", () => {
-                return utils.fetch_json(url_to_data + "gadm/derived/super-simplified-albanian-polygon.geojson").then(feature => {
-                    return load(url_to_data + "ghsl/tiles/GHS_POP_GPW42015_GLOBE_R2015A_54009_1k_v1_0_4326_60_40.tif").then(georaster => {
-                        let result = sum(georaster, turf_polygon(polygon))[0];
-                        console.log("result:", result);
-                        expect(result).to.equal(0);
-                    });
-                });
-            });
-        });
-        describe("Get Populations", function() {
-            this.timeout(1000000); 
-            it("Got Correct Populations for a Sample of Countries", () => {
-                let countries = [
-                  {"population": 790242.0, "name": "Cyprus"},
-                  {"population": 5066313.5, "name": "Nicaragua"},
-                  {"population": 5554059.5, "name": "Lebanon"},
-                  {"population": 2332581.75, "name": "Jamaica"},
-                  {"population": 4685367.5, "name": "Croatia"},
-                  {"population": 2234089.5, "name": "Macedonia"},
-                  {"population": 3303561.5, "name": "Uruguay"}
-                ];
-                //console.log("countries:", countries);
-                let promises = countries.map(country => {
-                    //console.log("country:", country);
-                    return fetch_json(url_to_geojsons + country.name + ".geojson").then(country_geojson => {
-                        //console.log("country_geojson:", country_geojson);
-                        let country_bbox = turf_bbox(country_geojson);
-                        //console.log("country_bbox:", country_bbox);
-                        let [minX, minY, maxX, maxY] = country_bbox;
-                        let left = Math.round((minX - 5) / 10) * 10;
-                        let right = Math.round((maxX - 5) / 10) * 10;
-                        let _bottom = 90 - 10 * Math.floor((90 - minY) / 10);
-                        let _top = 90 - 10 * Math.floor((90 - maxY) / 10);
-                        //console.log("rounded:", [left, _bottom, right, _top]);
-                   
-                        let latitudes = _.range(_top, _bottom -1, -10);
-                        //console.log("latitudes:", latitudes);
-                        let longitudes = _.range(left, right + 1, 10);
-                        //console.log("longitudes:", longitudes);
-                        let tiles = [];
-                        latitudes.forEach(latitude => {
-                            longitudes.forEach(longitude => {
-                                tiles.push(load(url_to_data + "ghsl/tiles/GHS_POP_GPW42015_GLOBE_R2015A_54009_1k_v1_0_4326_" + longitude + "_" + latitude + ".tif"));
-                            });
-                        });
-                        return Promise.all(tiles).then(georasters => {
-                            //console.log("georaster tiles:", JSON.stringify(georasters.map(g => [g.xmin, g.ymax])));
-                            //console.log("country_geojson:", country_geojson.type);
-                            let total_sum = 0;
-                            if (country_geojson.geometry.type === "MultiPolygon") {
-                                //console.log("country is multipolygon");
-                                country_geojson.geometry.coordinates.map((polygon, polygon_index) => {
-
-                                    if (polygon_index === 129) {
-                                        fs.writeFile("/tmp/poly" + polygon_index + ".geojson", JSON.stringify(turf_polygon(polygon)));
-                                    }
-                                    try {
-                                        georasters.forEach(georaster => {
-                                            //console.log("\n\ngetting sum for polygon", polygon_index, "and georaster", Math.round(georaster.xmin), Math.round(georaster.ymax));
-                                            let partial_sum = sum(georaster, turf_polygon(polygon));
-                                            //console.log("partial_sum:", partial_sum, typeof partial_sum);
-                                            if (Array.isArray(partial_sum)) partial_sum = partial_sum[0];
-                                            if (partial_sum > 0) {
-                                                total_sum += partial_sum;
-                                                //console.log("total_sum:", total_sum);
-                                            }
-                                        });
-                                    } catch (error) {
-                                        console.error("Caught error on polygon_index:", polygon_index);
-                                        fs.writeFile("/tmp/poly" + polygon_index + ".geojson", JSON.stringify(turf_polygon(polygon)));
-                                        throw error;
-                                    }
-                                });
-                            } else {
-                                //total_sum = georasters.map(georaster => sum(georaster, country_geojson)[0]);
-                                georasters.forEach(georaster => {
-                                    let partial_sum = sum(georaster, country_geojson);
-                                    //console.log("partial_sum:", partial_sum, typeof partial_sum);
-                                    if (Array.isArray(partial_sum)) partial_sum = partial_sum[0];
-                                    if (partial_sum > 0) {
-                                        total_sum += partial_sum;
-                                        //console.log("total_sum:", total_sum);
-                                    }
-                                });
-                            }
-                            //let total_sum = georasters.reduce((running_sum, georaster) => running_sum + (sum(georaster, country_geojson)[0] || 0), 0);
-                            //console.log("country.population:", country.population);
-                            console.log("\tcomputed population of " + country.name + ": " + Math.round(total_sum).toLocaleString());
-                            let percent_off = Math.abs(country.population - total_sum) / country.population;
-                            console.log("percent_off:", percent_off);
-                            expect(percent_off).to.be.below(0.05);
-                            //expect(total_sum.toLocaleString()).to.equal(country.population.toLocaleString());
-                        });
-                    });
-                });
-                return Promise.all(promises);
-            });
-        });
+      });
     });
+    describe('Get Sum from Bounding Box', function() {
+      this.timeout(1000000);
+      it('Got Correct Value', () => {
+        return load(url).then(georaster => {
+          let value = Number(sum(georaster, bbox)[0].toFixed(2));
+          expect(value).to.equal(expected_bbox_value);
+        });
+      });
+    });
+    describe('Get Sum from Bounding Box Greater Then Raster', function() {
+      this.timeout(1000000);
+      it('Got Correct Value', () => {
+        return load(url_rwanda).then(georaster => {
+          let value_with_buffered_bbox = Number(sum(georaster, bbox_rwanda)[0].toFixed(2));
+          let value_without_bbox = Number(sum(georaster)[0].toFixed(2));
+          expect(value_with_buffered_bbox).to.equal(104848.45);
+          expect(value_without_bbox).to.equal(104848.45);
+          expect(value_with_buffered_bbox).to.equal(value_without_bbox);
+        });
+      });
+    });
+    describe('Get Same Sum from GeoJSON and ESRI JSON', function() {
+      this.timeout(1000000);
+      it('Got Matching Value', () => {
+        let url_to_raster = url_to_data + "mapspam/spam2005v3r2_harvested-area_wheat_total.tiff";
+        return load(url_to_raster).then(georaster => {
+          let country_names = ["Afghanistan", "Ukraine"];
+          let promises = country_names.map(name => {
+            return fetch_jsons([url_to_geojsons + name + ".geojson", url_to_arcgis_jsons + name + ".json"], true)
+            .then(jsons => {
+              let [geojson, arcgis_json] = jsons;
+              let value_via_geojson = Number(sum(georaster, geojson)[0].toFixed(2));
+              let value_via_arcgis_json = Number(sum(georaster, arcgis_json)[0].toFixed(2));
+              let value_via_arcgis_json_polygon = Number(sum(georaster, arcgis_json.geometry)[0].toFixed(2));
+              console.log("value_via_arcgis_json:", value_via_arcgis_json);
+              expect(value_via_geojson).to.equal(value_via_arcgis_json);
+              expect(value_via_geojson).to.equal(value_via_arcgis_json_polygon);
+            });
+          });
+          return Promise.all(promises);
+        });
+      });
+    });
+    describe('Get Sum from Polygon', function() {
+      this.timeout(1000000);
+      it('Got Correct Value', () => {
+        return load(url).then(georaster => {
+          let value = Number(sum(georaster, polygon)[0].toFixed(2));
+          expect(value).to.equal(expected_polygon_value);
+        });
+      });
+    });
+    describe('Get Sum from Polygon (GeoJSON) 1', function() {
+      this.timeout(1000000);
+      it('Got Correct Value', () => {
+        return load(url).then(georaster => {
+          let value = Number(sum(georaster, polygon_geojson_1)[0].toFixed(2));
+          expect(value).to.equal(expected_polygon_geojson_value_1);
+        });
+      });
+    });
+    describe('Get Sum from Polygon (GeoJSON) 2', function() {
+      this.timeout(1000000);
+      it('Got Correct Value', () => {
+        return load(url).then(georaster => {
+          let value = Number(sum(georaster, polygon_geojson_2)[0].toFixed(2));
+          expect(value).to.equal(expected_polygon_geojson_value_2);
+        });
+      });
+    });
+    describe('Get Sum from Polygon (Multi-Polygon GeoJSON, 1 + 2)', function() {
+      this.timeout(1000000);
+      it('Got Correct Value', () => {
+        return load(url).then(georaster => {
+          let value = Number(sum(georaster, polygon_geojson_collection)[0].toFixed(2));
+          expect(value).to.equal(expected_polygon_geojson_collection_value);
+        });
+      });
+    });
+    describe("Test sum for Country with Multiple Rings", function() {
+      this.timeout(1000000);
+      it("Got correct sum", () => {
+        return load(url).then(georaster => {
+          return utils.fetch_json(url_to_geojsons + "Akrotiri and Dhekelia.geojson")
+          .then(country => {
+            let value = sum(georaster, country);
+            console.log("value:", value);
+          });
+        });
+      });
+    });
+    describe('Get Sum from Polygon Above X Value', function() {
+      this.timeout(1000000);
+      it('Got Correct Value', () => {
+        return load(url).then(georaster => {
+          let value = Number(sum(georaster, polygon, v => v > 3000)[0].toFixed(2));
+          expect(value).to.equal(1501820.8);
+        });
+      });
+    });
+    describe("Test Super Simplified Albanian Polygon", function() {
+      it("Finish calculation", () => {
+        return utils.fetch_json(url_to_data + "gadm/derived/super-simplified-albanian-polygon.geojson").then(feature => {
+          return load(url_to_data + "ghsl/tiles/GHS_POP_GPW42015_GLOBE_R2015A_54009_1k_v1_0_4326_60_40.tif").then(georaster => {
+            let result = sum(georaster, turf_polygon(polygon))[0];
+            console.log("result:", result);
+            expect(result).to.equal(0);
+          });
+        });
+      });
+    });
+    describe("Get Populations", function() {
+      this.timeout(1000000);
+      it("Got Correct Populations for a Sample of Countries", () => {
+        let countries = [
+          {"population": 790242.0, "name": "Cyprus"},
+          {"population": 5066313.5, "name": "Nicaragua"},
+          {"population": 5554059.5, "name": "Lebanon"},
+          {"population": 2332581.75, "name": "Jamaica"},
+          {"population": 4685367.5, "name": "Croatia"},
+          {"population": 2234089.5, "name": "Macedonia"},
+          {"population": 3303561.5, "name": "Uruguay"}
+        ];
+        //console.log("countries:", countries);
+        let promises = countries.map(country => {
+          //console.log("country:", country);
+          return fetch_json(url_to_geojsons + country.name + ".geojson").then(country_geojson => {
+            //console.log("country_geojson:", country_geojson);
+            let country_bbox = turf_bbox(country_geojson);
+            //console.log("country_bbox:", country_bbox);
+            let [minX, minY, maxX, maxY] = country_bbox;
+            let left = Math.round((minX - 5) / 10) * 10;
+            let right = Math.round((maxX - 5) / 10) * 10;
+            let _bottom = 90 - 10 * Math.floor((90 - minY) / 10);
+            let _top = 90 - 10 * Math.floor((90 - maxY) / 10);
+            //console.log("rounded:", [left, _bottom, right, _top]);
+
+            let latitudes = _.range(_top, _bottom -1, -10);
+            //console.log("latitudes:", latitudes);
+            let longitudes = _.range(left, right + 1, 10);
+            //console.log("longitudes:", longitudes);
+            let tiles = [];
+            latitudes.forEach(latitude => {
+              longitudes.forEach(longitude => {
+                tiles.push(load(url_to_data + "ghsl/tiles/GHS_POP_GPW42015_GLOBE_R2015A_54009_1k_v1_0_4326_" + longitude + "_" + latitude + ".tif"));
+              });
+            });
+            return Promise.all(tiles).then(georasters => {
+              //console.log("georaster tiles:", JSON.stringify(georasters.map(g => [g.xmin, g.ymax])));
+              //console.log("country_geojson:", country_geojson.type);
+              let total_sum = 0;
+              if (country_geojson.geometry.type === "MultiPolygon") {
+                //console.log("country is multipolygon");
+                country_geojson.geometry.coordinates.map((polygon, polygon_index) => {
+
+                  if (polygon_index === 129) {
+                    fs.writeFile("/tmp/poly" + polygon_index + ".geojson", JSON.stringify(turf_polygon(polygon)));
+                  }
+                  try {
+                    georasters.forEach(georaster => {
+                      //console.log("\n\ngetting sum for polygon", polygon_index, "and georaster", Math.round(georaster.xmin), Math.round(georaster.ymax));
+                      let partial_sum = sum(georaster, turf_polygon(polygon));
+                      //console.log("partial_sum:", partial_sum, typeof partial_sum);
+                      if (Array.isArray(partial_sum)) partial_sum = partial_sum[0];
+                      if (partial_sum > 0) {
+                        total_sum += partial_sum;
+                        //console.log("total_sum:", total_sum);
+                      }
+                    });
+                  } catch (error) {
+                    console.error("Caught error on polygon_index:", polygon_index);
+                    fs.writeFile("/tmp/poly" + polygon_index + ".geojson", JSON.stringify(turf_polygon(polygon)));
+                    throw error;
+                  }
+                });
+              } else {
+                //total_sum = georasters.map(georaster => sum(georaster, country_geojson)[0]);
+                georasters.forEach(georaster => {
+                  let partial_sum = sum(georaster, country_geojson);
+                  //console.log("partial_sum:", partial_sum, typeof partial_sum);
+                  if (Array.isArray(partial_sum)) partial_sum = partial_sum[0];
+                  if (partial_sum > 0) {
+                    total_sum += partial_sum;
+                    //console.log("total_sum:", total_sum);
+                  }
+                });
+              }
+              //let total_sum = georasters.reduce((running_sum, georaster) => running_sum + (sum(georaster, country_geojson)[0] || 0), 0);
+              //console.log("country.population:", country.population);
+              console.log("\tcomputed population of " + country.name + ": " + Math.round(total_sum).toLocaleString());
+              let percent_off = Math.abs(country.population - total_sum) / country.population;
+              console.log("percent_off:", percent_off);
+              expect(percent_off).to.be.below(0.05);
+              //expect(total_sum.toLocaleString()).to.equal(country.population.toLocaleString());
+            });
+          });
+        });
+        return Promise.all(promises);
+      });
+    });
+  });
 }
 
 test();

--- a/packages/utils/test.js
+++ b/packages/utils/test.js
@@ -16,201 +16,201 @@ let in_browser = typeof window === 'object';
 let fetch = in_browser ? window.fetch : require('node-fetch');
 
 let test = () => {
-    describe('Get Bounding Box', function() {
-        describe('Get Bounding when Bounding Box when Bigger Than Raster', function() {
-            this.timeout(1000000);
-            it('Got Correct Bounding Box with Negative Values', () => {
-                return load(url).then(georaster => {
-                    let bbox_with_buffer = {
-                        xmin: georaster.xmin - 1,
-                        xmax: georaster.xmax + 1,
-                        ymin: georaster.ymin - 1,
-                        ymax: georaster.ymax + 1
-                    };
-                    let actual_bbox = utils.convert_crs_bbox_to_image_bbox(georaster, bbox_with_buffer);
-                    expect(actual_bbox.xmin).to.be.below(0);
-                    expect(actual_bbox.xmin).to.be.below(actual_bbox.xmax);
-                    expect(actual_bbox.ymin).to.be.below(0);
-                    expect(actual_bbox.ymin).to.be.below(actual_bbox.ymax);
-                });
-            });
+  describe('Get Bounding Box', function() {
+    describe('Get Bounding when Bounding Box when Bigger Than Raster', function() {
+      this.timeout(1000000);
+      it('Got Correct Bounding Box with Negative Values', () => {
+        return load(url).then(georaster => {
+          let bbox_with_buffer = {
+            xmin: georaster.xmin - 1,
+            xmax: georaster.xmax + 1,
+            ymin: georaster.ymin - 1,
+            ymax: georaster.ymax + 1
+          };
+          let actual_bbox = utils.convert_crs_bbox_to_image_bbox(georaster, bbox_with_buffer);
+          expect(actual_bbox.xmin).to.be.below(0);
+          expect(actual_bbox.xmin).to.be.below(actual_bbox.xmax);
+          expect(actual_bbox.ymin).to.be.below(0);
+          expect(actual_bbox.ymin).to.be.below(actual_bbox.ymax);
         });
-        describe("Get Bounding Box of GeoJSON that has MultiPolygon Geometry (i.e., multiple rings)", function() {
-            this.timeout(1000000);
-            it("Got correct bounding box", () => {
-                return fetch_json(url_to_geojson)
-                .then(country => {
-                    let bbox = utils.get_bounding_box(country.geometry.coordinates);
-                    expect(typeof bbox.xmin).to.equal("number");
-                    expect(typeof bbox.xmax).to.equal("number");
-                    expect(typeof bbox.ymin).to.equal("number");
-                    expect(typeof bbox.ymax).to.equal("number");
-                    expect(bbox.xmin).to.equal(32.76010131835966);
-                    expect(bbox.xmax).to.equal(33.92147445678711);
-                    expect(bbox.ymin).to.equal(34.56208419799816);
-                    expect(bbox.ymax).to.equal(35.118995666503906);
-                });
-            });
-        });
+      });
     });
-    describe("Test Forcing Within", function() {
-        describe("For simple examples", function() {
-            it("Got correct values", () => {
-                expect(utils.force_within(10, 1, 11)).to.equal(10);
-                expect(utils.force_within(-10, 1, 11)).to.equal(1);
-                expect(utils.force_within(990, 1, 11)).to.equal(11);
-            });
+    describe("Get Bounding Box of GeoJSON that has MultiPolygon Geometry (i.e., multiple rings)", function() {
+      this.timeout(1000000);
+      it("Got correct bounding box", () => {
+        return fetch_json(url_to_geojson)
+        .then(country => {
+          let bbox = utils.get_bounding_box(country.geometry.coordinates);
+          expect(typeof bbox.xmin).to.equal("number");
+          expect(typeof bbox.xmax).to.equal("number");
+          expect(typeof bbox.ymin).to.equal("number");
+          expect(typeof bbox.ymax).to.equal("number");
+          expect(bbox.xmin).to.equal(32.76010131835966);
+          expect(bbox.xmax).to.equal(33.92147445678711);
+          expect(bbox.ymin).to.equal(34.56208419799816);
+          expect(bbox.ymax).to.equal(35.118995666503906);
         });
+      });
     });
-    describe("Test Merging of Index Ranges", function() {
-        it("Got Correct Values", function() {
-            let original =  [ [0, 10], [10, 10], [20, 30], [30, 40] ];
-            let merged = utils.merge_ranges(original);
-            expect(JSON.stringify(merged)).to.equal('[[0,10],[20,40]]');
+  });
+  describe("Test Forcing Within", function() {
+    describe("For simple examples", function() {
+      it("Got correct values", () => {
+        expect(utils.force_within(10, 1, 11)).to.equal(10);
+        expect(utils.force_within(-10, 1, 11)).to.equal(1);
+        expect(utils.force_within(990, 1, 11)).to.equal(11);
+      });
+    });
+  });
+  describe("Test Merging of Index Ranges", function() {
+    it("Got Correct Values", function() {
+      let original =  [ [0, 10], [10, 10], [20, 30], [30, 40] ];
+      let merged = utils.merge_ranges(original);
+      expect(JSON.stringify(merged)).to.equal('[[0,10],[20,40]]');
 
-            original =  [ [0, 10], [10, 10], [21, 31], [30, 40] ];
-            merged = utils.merge_ranges(original);
-            expect(JSON.stringify(merged)).to.equal('[[0,10],[21,40]]');
- 
-        });
-    });
-    describe("Test Get Depth", function() {
-        describe("For Multipolygon", function() {
-            this.timeout(1000000);
-            it("Get Correct Depth", () => {
-                let country_depths = [["Afghanistan", 3], ['Akrotiri and Dhekelia', 4]];
-                let promises = country_depths.map(country_depth => {
-                    let [country, depth] = country_depth;
-                    return fetch_json(url_to_geojsons + country + ".geojson")
-                    .then(country => {
-                        let actual_depth = utils.get_depth(country.geometry.coordinates);
-                        expect(actual_depth).to.equal(depth);
-                    });
-                });
-                return Promise.all(promises);
-            });
-        });
-    });
-    describe("Test Clustering Of Line Segments", function() {
-        describe("For array of objects holding information about intersections", function() {
-            it("Got Correct Split", () => {
-                
-                let segments, computed, computed_number_of_clusters;
-                
-                segments = [{ends_off_line: true}, {ends_off_line: false}, {ends_off_line: false}, {ends_off_line: true}];
-                computed = utils.cluster(segments, s => s.ends_off_line);
-                computed_number_of_clusters = computed.length;
-                expect(computed_number_of_clusters).to.equal(2);
-                expect(computed[0].length).to.equal(1);
-                expect(computed[1].length).to.equal(3);
+      original =  [ [0, 10], [10, 10], [21, 31], [30, 40] ];
+      merged = utils.merge_ranges(original);
+      expect(JSON.stringify(merged)).to.equal('[[0,10],[21,40]]');
 
-                segments = [{ends_off_line: true, index: 0}, {ends_off_line: false}, {ends_off_line: false}, {ends_off_line: false, index: 99}];
-                computed = utils.cluster(segments, s => s.ends_off_line);
-                console.log("computed:", computed);
-                computed_number_of_clusters = computed.length;
-                expect(computed_number_of_clusters).to.equal(2);
-                expect(computed[0].length).to.equal(1);
-                expect(computed[1].length).to.equal(3);
-                
-                segments = [{ends_off_line: true, index: 0}, {ends_off_line: false}, {ends_off_line: false}, {ends_off_line: false, ends_on_line: true, index: 99}];
-                computed = utils.cluster_line_segments(segments, 100, true);
-                console.log("computed:", computed);
-                computed_number_of_clusters = computed.length;
-                expect(computed_number_of_clusters).to.equal(1);
-                expect(computed[0].length).to.equal(4);
-                
-            });
-        });
     });
-    describe("Test Coupling", function() {
-        it("Got Correct Couples", () => {
-            let items = [0, 1, 18, 77, 99, 103];
-            let actual = utils.couple(items);
-            expect(actual).to.have.lengthOf(items.length / 2);
-            actual.map(couple => {
-                expect(couple).to.have.lengthOf(2);
-            });
+  });
+  describe("Test Get Depth", function() {
+    describe("For Multipolygon", function() {
+      this.timeout(1000000);
+      it("Get Correct Depth", () => {
+        let country_depths = [["Afghanistan", 3], ['Akrotiri and Dhekelia', 4]];
+        let promises = country_depths.map(country_depth => {
+          let [country, depth] = country_depth;
+          return fetch_json(url_to_geojsons + country + ".geojson")
+          .then(country => {
+            let actual_depth = utils.get_depth(country.geometry.coordinates);
+            expect(actual_depth).to.equal(depth);
+          });
         });
+        return Promise.all(promises);
+      });
     });
-    describe("Test is_polygon", function() {
-        it("Got all trues", () => {
-            let countries = ["Afghanistan", "Ukraine"];
-            let promises = countries.map(name => {
-                return fetch_jsons([url_to_geojsons + name + ".geojson", url_to_arcgis_jsons + name + ".json"]).then(jsons => {
-                    let [geojson, arcgisjson] = jsons;
-                    console.log("geojson:", JSON.stringify(geojson).substring(0, 100) + "...");
-                    console.log("arcgisjson:", JSON.stringify(arcgisjson).substring(0, 100) + "...");
-                    expect(utils.is_polygon(geojson)).to.equal(true);
-                    expect(utils.is_polygon(arcgisjson)).to.equal(true);
-                    expect(utils.is_polygon(arcgisjson.geometry)).to.equal(true);
-                });
-            });
-            return Promise.all(promises);
+  });
+  describe("Test Clustering Of Line Segments", function() {
+    describe("For array of objects holding information about intersections", function() {
+      it("Got Correct Split", () => {
+
+        let segments, computed, computed_number_of_clusters;
+
+        segments = [{ends_off_line: true}, {ends_off_line: false}, {ends_off_line: false}, {ends_off_line: true}];
+        computed = utils.cluster(segments, s => s.ends_off_line);
+        computed_number_of_clusters = computed.length;
+        expect(computed_number_of_clusters).to.equal(2);
+        expect(computed[0].length).to.equal(1);
+        expect(computed[1].length).to.equal(3);
+
+        segments = [{ends_off_line: true, index: 0}, {ends_off_line: false}, {ends_off_line: false}, {ends_off_line: false, index: 99}];
+        computed = utils.cluster(segments, s => s.ends_off_line);
+        console.log("computed:", computed);
+        computed_number_of_clusters = computed.length;
+        expect(computed_number_of_clusters).to.equal(2);
+        expect(computed[0].length).to.equal(1);
+        expect(computed[1].length).to.equal(3);
+
+        segments = [{ends_off_line: true, index: 0}, {ends_off_line: false}, {ends_off_line: false}, {ends_off_line: false, ends_on_line: true, index: 99}];
+        computed = utils.cluster_line_segments(segments, 100, true);
+        console.log("computed:", computed);
+        computed_number_of_clusters = computed.length;
+        expect(computed_number_of_clusters).to.equal(1);
+        expect(computed[0].length).to.equal(4);
+
+      });
+    });
+  });
+  describe("Test Coupling", function() {
+    it("Got Correct Couples", () => {
+      let items = [0, 1, 18, 77, 99, 103];
+      let actual = utils.couple(items);
+      expect(actual).to.have.lengthOf(items.length / 2);
+      actual.map(couple => {
+        expect(couple).to.have.lengthOf(2);
+      });
+    });
+  });
+  describe("Test is_polygon", function() {
+    it("Got all trues", () => {
+      let countries = ["Afghanistan", "Ukraine"];
+      let promises = countries.map(name => {
+        return fetch_jsons([url_to_geojsons + name + ".geojson", url_to_arcgis_jsons + name + ".json"]).then(jsons => {
+          let [geojson, arcgisjson] = jsons;
+          console.log("geojson:", JSON.stringify(geojson).substring(0, 100) + "...");
+          console.log("arcgisjson:", JSON.stringify(arcgisjson).substring(0, 100) + "...");
+          expect(utils.is_polygon(geojson)).to.equal(true);
+          expect(utils.is_polygon(arcgisjson)).to.equal(true);
+          expect(utils.is_polygon(arcgisjson.geometry)).to.equal(true);
         });
+      });
+      return Promise.all(promises);
     });
-    describe("Test Intersections", function() {
-        it("Got correct values", () => {
-            let edge1 = [[32.87069320678728,34.66652679443354],[32.87069320678728,34.66680526733393]]; // vertical
-            let edge2 = [[30,34.70833333333334],[40,34.70833333333334]];
-            let line_1 = utils.get_line_from_points(edge1[0], edge1[1]);
-            let line_2 = utils.get_line_from_points(edge2[0], edge2[1]);
-            let intersection = utils.get_intersection_of_two_lines(line_1, line_2);
-            expect(intersection.x).to.equal(32.87069320678728);
-            expect(intersection.y).to.equal(34.70833333333334);
+  });
+  describe("Test Intersections", function() {
+    it("Got correct values", () => {
+      let edge1 = [[32.87069320678728,34.66652679443354],[32.87069320678728,34.66680526733393]]; // vertical
+      let edge2 = [[30,34.70833333333334],[40,34.70833333333334]];
+      let line_1 = utils.get_line_from_points(edge1[0], edge1[1]);
+      let line_2 = utils.get_line_from_points(edge2[0], edge2[1]);
+      let intersection = utils.get_intersection_of_two_lines(line_1, line_2);
+      expect(intersection.x).to.equal(32.87069320678728);
+      expect(intersection.y).to.equal(34.70833333333334);
 
-            // this test fails because of floating point arithmetic
-            let vertical_edge = [ [ 19.59097290039091, 29.76190948486328 ], [ 19.59097290039091, 41.76180648803728 ] ];
-            let horizontal_edge = [ [ 15, 41.641892470257524 ], [ 25, 41.641892470257524 ] ];
-            let vertical_line = utils.get_line_from_points(vertical_edge[0], vertical_edge[1]);
-            let horizontal_line = utils.get_line_from_points(horizontal_edge[0], horizontal_edge[1]);
-            console.log("line_1, line_2", vertical_line, horizontal_line);
-            intersection = utils.get_intersection_of_two_lines(vertical_line, horizontal_line);
-            console.log("intersection:", intersection);
-            //expect(intersection.x).to.equal(19.59097290039091);
-            //expect(intersection.y).to.equal(41.641892470257524);
-        });
+      // this test fails because of floating point arithmetic
+      let vertical_edge = [ [ 19.59097290039091, 29.76190948486328 ], [ 19.59097290039091, 41.76180648803728 ] ];
+      let horizontal_edge = [ [ 15, 41.641892470257524 ], [ 25, 41.641892470257524 ] ];
+      let vertical_line = utils.get_line_from_points(vertical_edge[0], vertical_edge[1]);
+      let horizontal_line = utils.get_line_from_points(horizontal_edge[0], horizontal_edge[1]);
+      console.log("line_1, line_2", vertical_line, horizontal_line);
+      intersection = utils.get_intersection_of_two_lines(vertical_line, horizontal_line);
+      console.log("intersection:", intersection);
+      //expect(intersection.x).to.equal(19.59097290039091);
+      //expect(intersection.y).to.equal(41.641892470257524);
     });
-    describe("Test Categorization of Intersections", function() {
-        describe("For sample of intersections", function() {
-            it("Got Correct Categorization", () => {
-                // through
-                let segments = [{xmin: -140, xmax: -140, direction: 1}];
-                let actual = utils.categorize_intersection(segments);
-                expect(actual.through).to.equal(true);
-                expect(actual.xmin).to.equal(-140);
-                expect(actual.xmax).to.equal(-140);
+  });
+  describe("Test Categorization of Intersections", function() {
+    describe("For sample of intersections", function() {
+      it("Got Correct Categorization", () => {
+        // through
+        let segments = [{xmin: -140, xmax: -140, direction: 1}];
+        let actual = utils.categorize_intersection(segments);
+        expect(actual.through).to.equal(true);
+        expect(actual.xmin).to.equal(-140);
+        expect(actual.xmax).to.equal(-140);
 
-                // rebound
-                segments = [{xmin: -140, xmax: -140, direction: 1},{xmin: -140, xmax: -140, direction: -1}];
-                actual = utils.categorize_intersection(segments);
-                expect(actual.through).to.equal(false);
-                expect(actual.xmin).to.equal(-140);
-                expect(actual.xmax).to.equal(-140);
+        // rebound
+        segments = [{xmin: -140, xmax: -140, direction: 1},{xmin: -140, xmax: -140, direction: -1}];
+        actual = utils.categorize_intersection(segments);
+        expect(actual.through).to.equal(false);
+        expect(actual.xmin).to.equal(-140);
+        expect(actual.xmax).to.equal(-140);
 
-                // horizontal through
-                segments = [{xmin: -140, xmax: -140, direction: 1},{xmin: -140, xmax: -130, direction: 0},{xmin: -130, xmax: -130, direction: 1}];
-                actual = utils.categorize_intersection(segments);
-                expect(actual.through).to.equal(true);
-                expect(actual.xmin).to.equal(-140);
-                expect(actual.xmax).to.equal(-130);
+        // horizontal through
+        segments = [{xmin: -140, xmax: -140, direction: 1},{xmin: -140, xmax: -130, direction: 0},{xmin: -130, xmax: -130, direction: 1}];
+        actual = utils.categorize_intersection(segments);
+        expect(actual.through).to.equal(true);
+        expect(actual.xmin).to.equal(-140);
+        expect(actual.xmax).to.equal(-130);
 
-                // horizontal rebound
-                segments = [{xmin: -140, xmax: -140, direction: 1},{xmin: -140, xmax: -130, direction: 0},{xmin: -130, xmax: -130, direction: -1}];
-                actual = utils.categorize_intersection(segments);
-                expect(actual.through).to.equal(false);
-                expect(actual.xmin).to.equal(-140);
-                expect(actual.xmax).to.equal(-130);
+        // horizontal rebound
+        segments = [{xmin: -140, xmax: -140, direction: 1},{xmin: -140, xmax: -130, direction: 0},{xmin: -130, xmax: -130, direction: -1}];
+        actual = utils.categorize_intersection(segments);
+        expect(actual.through).to.equal(false);
+        expect(actual.xmin).to.equal(-140);
+        expect(actual.xmax).to.equal(-130);
 
-                // through with stop
-                segments = [{xmin: -140, xmax: -140, direction: 1}, {xmin: -140, xmax: -140, direction: 1}];
-                actual = utils.categorize_intersection(segments);
-                expect(actual.through).to.equal(true);
-                expect(actual.xmin).to.equal(-140);
-                expect(actual.xmax).to.equal(-140);
+        // through with stop
+        segments = [{xmin: -140, xmax: -140, direction: 1}, {xmin: -140, xmax: -140, direction: 1}];
+        actual = utils.categorize_intersection(segments);
+        expect(actual.through).to.equal(true);
+        expect(actual.xmin).to.equal(-140);
+        expect(actual.xmax).to.equal(-140);
 
-            });
-        });
+      });
     });
+  });
 }
 
 test();

--- a/packages/utils/utils.js
+++ b/packages/utils/utils.js
@@ -13,486 +13,486 @@ let ArcGIS = require('terraformer-arcgis-parser');
 
 
 function fetch_json(url) {
-    return fetch(url).then(response => response.json());
+  return fetch(url).then(response => response.json());
 }
 
 function fetch_jsons(urls, debug=false) {
-    if (debug) console.log("starting fetch_jsons with", urls);
-    try {
-        return Promise.all(urls.map(fetch_json));
-    } catch (error) {
-        console.error("urls:", urls);
-        console.error(error);
-        throw error;
-    }
+  if (debug) console.log("starting fetch_jsons with", urls);
+  try {
+    return Promise.all(urls.map(fetch_json));
+  } catch (error) {
+    console.error("urls:", urls);
+    console.error(error);
+    throw error;
+  }
 }
 
 /*
-    Runs on each value in a table,
-    represented by an array of rows.
+  Runs on each value in a table,
+  represented by an array of rows.
 */
 function run_on_table_of_values(table, no_data_value, run_on_values) {
-    let number_of_rows = table.length;
-    for (let row_index = 0; row_index < number_of_rows; row_index++) {
-        let row = table[row_index];
-        let number_of_cells = row.length;
-        for (let column_index = 0; column_index < number_of_cells; column_index++) {
-            let value = row[column_index]; 
-            if (value !== no_data_value) {
-                run_on_values(value);
-            }
-        }
+  let number_of_rows = table.length;
+  for (let row_index = 0; row_index < number_of_rows; row_index++) {
+    let row = table[row_index];
+    let number_of_cells = row.length;
+    for (let column_index = 0; column_index < number_of_cells; column_index++) {
+      let value = row[column_index];
+      if (value !== no_data_value) {
+        run_on_values(value);
+      }
     }
+  }
 }
 
 function get_bounding_box(geometry) {
 
-    let xmin, ymin, xmax, ymax;
+  let xmin, ymin, xmax, ymax;
 
-    if (typeof(geometry[0][0]) === "number") {
-        let number_of_points = geometry.length;
-        xmin = xmax = geometry[0][0];
-        ymin = ymax = geometry[0][1];
-        for (let i = 1; i < number_of_points; i++) {
-            let [x, y] = geometry[i];
-            if (x < xmin) xmin = x;
-            else if (x > xmax) xmax = x;
-            if (y < ymin) ymin = y;
-            else if (y > ymax) ymax = y;
-        }
-    } else {
-        let bboxes = geometry.forEach((part, index) => {
-            let bbox = get_bounding_box(part);
-            if (index == 0) {
-                xmin = bbox.xmin;
-                xmax = bbox.xmax;
-                ymin = bbox.ymin;
-                ymax = bbox.ymax;
-            } else {
-                if (bbox.xmin < xmin) xmin = bbox.xmin;
-                else if (bbox.xmax > xmax) xmax = bbox.xmax;
-                if (bbox.ymin < ymin) ymin = bbox.ymin;
-                else if (bbox.ymax > ymax) ymax = bbox.ymax;
-            }
-        });
+  if (typeof(geometry[0][0]) === "number") {
+    let number_of_points = geometry.length;
+    xmin = xmax = geometry[0][0];
+    ymin = ymax = geometry[0][1];
+    for (let i = 1; i < number_of_points; i++) {
+      let [x, y] = geometry[i];
+      if (x < xmin) xmin = x;
+      else if (x > xmax) xmax = x;
+      if (y < ymin) ymin = y;
+      else if (y > ymax) ymax = y;
     }
+  } else {
+    let bboxes = geometry.forEach((part, index) => {
+      let bbox = get_bounding_box(part);
+      if (index == 0) {
+        xmin = bbox.xmin;
+        xmax = bbox.xmax;
+        ymin = bbox.ymin;
+        ymax = bbox.ymax;
+      } else {
+        if (bbox.xmin < xmin) xmin = bbox.xmin;
+        else if (bbox.xmax > xmax) xmax = bbox.xmax;
+        if (bbox.ymin < ymin) ymin = bbox.ymin;
+        else if (bbox.ymax > ymax) ymax = bbox.ymax;
+      }
+    });
+  }
 
-    return { xmin, ymin, xmax, ymax };
+  return { xmin, ymin, xmax, ymax };
 }
 
 function cluster(items, new_cluster_test) {
-    try {
-        let number_of_items = items.length;
-        let clusters = [];
-        let cluster = [];
-        for (let i = 0; i < number_of_items; i++) {
-            let item = items[i];
-            cluster.push(item);
-            if (new_cluster_test(item)) {
-                clusters.push(cluster);
-                cluster = [];
-            }
-        }
-        
-        if (cluster.length > 0) clusters.push(cluster);
-        
-        return clusters;
-    } catch (error) {
-        console.error("[cluster]:", error);
+  try {
+    let number_of_items = items.length;
+    let clusters = [];
+    let cluster = [];
+    for (let i = 0; i < number_of_items; i++) {
+      let item = items[i];
+      cluster.push(item);
+      if (new_cluster_test(item)) {
+        clusters.push(cluster);
+        cluster = [];
+      }
     }
+
+    if (cluster.length > 0) clusters.push(cluster);
+
+    return clusters;
+  } catch (error) {
+    console.error("[cluster]:", error);
+  }
 }
 
 function cluster_line_segments(line_segments, number_of_edges, debug=false) {
-    
-    try {
-        
-        let clusters = cluster(line_segments, s => s.ends_off_line);
-        
-        let number_of_clusters = clusters.length;
-        
-        if (debug) console.log("number_of_clusters", number_of_clusters);
-        
-        if (number_of_clusters >= 2) {
-            
-            let first_cluster = clusters[0];
-            let first_segment = first_cluster[0];
-            let last_cluster = _.last(clusters);
-            let last_segment = _.last(last_cluster);
-            
-            if (
-                last_segment.index === number_of_edges - 1
-                && first_segment.index === 0
-                && last_segment.ends_on_line
-            ) {
-                clusters[0] = clusters.pop().concat(first_cluster);
-            }
-            
-        }
-        
-        return clusters;  
-        
-    } catch (error) {
-        console.error("[cluster_line_segments]", error);
+
+  try {
+
+    let clusters = cluster(line_segments, s => s.ends_off_line);
+
+    let number_of_clusters = clusters.length;
+
+    if (debug) console.log("number_of_clusters", number_of_clusters);
+
+    if (number_of_clusters >= 2) {
+
+      let first_cluster = clusters[0];
+      let first_segment = first_cluster[0];
+      let last_cluster = _.last(clusters);
+      let last_segment = _.last(last_cluster);
+
+      if (
+        last_segment.index === number_of_edges - 1
+        && first_segment.index === 0
+        && last_segment.ends_on_line
+      ) {
+        clusters[0] = clusters.pop().concat(first_cluster);
+      }
+
     }
-    
+
+    return clusters;
+
+  } catch (error) {
+    console.error("[cluster_line_segments]", error);
+  }
+
 }
 
 module.exports = {
 
-    /**
-     * This function takes in an array with an even number of elements and returns an array that couples every two consecutive elements;
-     * @name couple
-     * @param {Object} array of anything
-     * @returns {Object} array of consecutive pairs
-     * @example
-     * let items = [0, 1, 18, 77, 99, 103];
-     * let unflattened = utils.couple(items);
-     * // unflattened
-     * // [ [0, 1], [18, 77], [99, 103] ]
-    */
-    couple(array) {
-        let couples = [];
-        let length_of_array = array.length;
-        for (let i = 0; i < length_of_array; i+=2) {
-            couples.push([ array[i], array[i+1] ]);
-        }
-        return couples;
-    },
-
-    force_within(n, min, max) {
-        if (n < min) n = min;
-        else if (n > max) n = max;
-        return n;
-    },
-
-    run_on_table_of_values,
-
-
-    /**
-     * This function categorizes an intersection 
-     * @name categorize_intersection
-     * @param {Object} edges
-    */ 
-    categorize_intersection(segments) {
-        try {
-            
-    
-            let through, end, xmin, xmax;
-    
-            let n = segments.length;
-
-            let first = segments[0];
-    
-            if (n === 1) {
-                through = true;
-                xmin = first.xmin;
-                xmax = first.xmax;
-            } else /* n > 1 */ {
-                let last = segments[n - 1];
-                through = first.direction === last.direction;
-                xmin = Math.min(first.xmin, last.xmin); 
-                xmax = Math.max(first.xmax, last.xmax);
-            }
-    
-            if (xmin === undefined || xmax === undefined || through === undefined || isNaN(xmin) || isNaN(xmax)) {
-                console.error("segments:", segments);
-                throw Error("categorize_intersection failed with xmin", xmin, "and xmax", xmax);
-            }
-    
-            return { xmin, xmax, through };
-            
-        } catch (error) {
-            
-            console.error("[categorize_intersection] segments:", segments);
-            console.error("[categorize_intersection]", error);
-            throw error;
-        }
-
-    },
-
-    convert_to_geojson_if_necessary(input, debug=false) {
-        if (this.is_esri_json(input, debug)) {
-            return this.toGeoJSON(input, debug);
-        } else {
-            return input;
-        }
-    },
-
-    count_values_in_table(table, no_data_value) {
-        let counts = {};
-        run_on_table_of_values(table, no_data_value, value => {
-            if (value in counts) counts[value]++;
-            else counts[value] = 1;
-        });
-        return counts;
-    },
-
-    convert_crs_bbox_to_image_bbox(georaster, crs_bbox) {
-
-        let crs_xmin, crs_ymin, crs_xmax, crs_ymax;
-        if (typeof crs_bbox.xmin !== "undefined") {
-            crs_xmin = crs_bbox.xmin;
-            crs_ymin = crs_bbox.ymin;
-            crs_xmax = crs_bbox.xmax;
-            crs_ymax = crs_bbox.ymax;
-        } else if (Array.isArray(crs_bbox) && crs_bbox.length === 4) {
-            // pull out bounding box values
-            crs_xmin = crs_bbox[0];
-            crs_ymin = crs_bbox[1];
-            crs_xmax = crs_bbox[2];
-            crs_ymax = crs_bbox[3];
-        }
-
-        // map bounding box values to image coordinate space
-        /* y_min uses lat_max while y_max uses lat_min because the image coordinate
-        system is inverted along the y axis relative to the lat/long (geographic)
-        coordinate system */
-        return {
-            xmin: Math.floor((crs_xmin - georaster.xmin) / georaster.pixelWidth),
-            ymin: Math.floor((georaster.ymax - crs_ymax) / georaster.pixelHeight),
-            xmax: Math.ceil((crs_xmax - georaster.xmin) / georaster.pixelWidth),
-            ymax: Math.ceil((georaster.ymax - crs_ymin) / georaster.pixelHeight)
-        };
-    },
-
-    get_geojson_coors(geojson, debug=false) {
-        if (debug) console.log("[get_geojson_coors] starting with", geojson);
-        let result;
-        if (geojson.features) { // for feature collections
-
-            // make sure that if any polygons are overlapping, we get the union of them
-            geojson = combine(geojson);
-            
-            // turf adds extra arrays when running combine, so we need to remove them
-            // as we return the coordinates
-            result = geojson.features[0].geometry.coordinates
-                .map(coors => coors[0]);
-        } else if (geojson.geometry) { // for individual feature
-            if (debug) console.log("[get_geojson_coors] hits geojson.geometry");
-            result = geojson.geometry.coordinates;
-        } else if (geojson.coordinates) { // for just the geometry
-            result = geojson.coordinates;
-        }
-        if (debug) console.log("[get_geojson_coors] returning", JSON.stringify(result).substring(0, 100) + "...");
-        return result;
-    },
-
-    is_bbox(geometry) {
-
-        if (geometry === undefined || geometry === null) {
-            return false;
-        }
-
-        // check if we are using the gio format and return true right away if so
-        if (geometry.xmin !== undefined && geometry.xmax !== undefined && geometry.ymax !== undefined && geometry.ymin !== undefined) {
-            return true;
-        }
-
-        if ((Array.isArray(geometry) && geometry.length === 4)) { // array 
-            return true;
-        }
-
-        // convert possible inputs to a list of coordinates
-        let coors;
-        if (typeof geometry === 'string') { // stringified geojson
-            let geojson = JSON.parse(geometry);
-            let geojson_coors = this.get_geojson_coors(geojson);
-            if (geojson_coors.length === 1 && geojson_coors[0].length === 5) {
-                coors = geojson_coors[0];
-            }
-        } else if (typeof geometry === 'object') { // geojson
-            let geojson_coors = this.get_geojson_coors(geometry);
-            if (geojson_coors) coors = geojson_coors[0];
-        } else {
-            return false;
-        }
-
-        // check to make sure coordinates make up a bounding box
-        if (coors && coors.length === 5 && _.isEqual(coors[0], coors[4])) {
-            let lngs = coors.map(coor => coor[0]);
-            let lats = coors.map(coor => coor[1]);
-            if (lngs[0] === lngs[3] && lats[0] === lats[1] && lngs[1] === lngs[2]) {
-                return true;
-            }
-        }
-        return false;
-    },
-
-    get_depth(geometry) {
-        let depth = 0;
-        let part = geometry;
-        while (Array.isArray(part)) {
-            depth++;
-            part = part[0];
-        }
-        return depth;
-    },
-
-    /**
-     * This function takes in an array of number pairs and combines where there's overlap
-     * @name 
-     * @param {Object} array of anything
-     * @returns {Object} array of index ranges
-     * @example
-     * let ranges = [ [0, 10], [10, 10], [20, 30], [30, 40] ];
-     * let merged_ranges = utils.merge_ranges(ranges);
-     * // merged_ranges
-     * // [ [0, 10], [20, 40] ]
-    */
-    merge_ranges(ranges) {
-        let number_of_ranges = ranges.length;
-        if (number_of_ranges > 0) {
-            let first_range = ranges[0];
-            let previous_end = first_range[1];
-            let previous_start = first_range[0];
-            let result = [first_range];
-            for (let i = 1; i < number_of_ranges; i++) {
-                let temp_range = ranges[i];
-                let [start, end] = temp_range;
-                if (start <= previous_end) {
-                    result[result.length - 1][1] = end;
-                } else {
-                    result.push(temp_range);
-                }
-                previous_end = end; 
-                previous_start = start;
-           }
-           return result;
-        }
-    },
-    
-    is_esri_json(input, debug=false) {
-        if (debug) console.log("starting is_esri_json with", input);
-        let input_type = typeof input;
-        let obj = input_type === "string" ? JSON.parse(input) : input_type === "object" ? input : null;
-        let geometry = obj.geometry ? obj.geometry : obj;
-        if (geometry) {
-            if (geometry.rings || (geometry.x && geometry.y)) {
-                try {
-                    if(ArcGIS.parse(obj)) {
-                        return true;
-                    } else {
-                        return false;
-                    }
-                } catch (error) {
-                    console.error(error);
-                    return false;
-                }
-            } else {
-                return false;
-            }
-        } else {
-            return false;
-        }
-    },
-    
-    toGeoJSON(input, debug=false) {
-        if (debug) console.log("[toGeoJSON] starting with", input);
-        let parsed = ArcGIS.toGeoJSON(input);
-        if (debug) console.log("[toGeoJSON] parsed:", parsed);
-        return Array.isArray(parsed) ? parsed[0] : parsed;
-    },
-
-    is_polygon(geometry, debug=false) {
-
-        // convert to a geometry
-        let coors;
-        if (Array.isArray(geometry)) {
-            coors = geometry;
-        } else if (typeof geometry === 'string') {
-            let parsed = JSON.parse(geometry);
-            let geojson = this.convert_to_geojson_if_necessary(parsed, debug);
-            coors = this.get_geojson_coors(geojson, debug);
-        } else if (typeof geometry === 'object') {
-            let geojson = this.convert_to_geojson_if_necessary(geometry, debug);
-            coors = this.get_geojson_coors(geojson, debug);
-        }
-
-        if (coors) {
-
-            // iterate through each geometry and make sure first and
-            // last point are the same
-
-            let depth = this.get_depth(coors);
-            if (debug) console.log("depth:", depth);
-            if (depth === 4) {
-                return coors.map(() => this.is_polygon).every(Boolean);
-            } else if (depth === 3) {
-                let is_polygon_array = true;
-                coors.forEach(part => {
-                    let first_vertex = part[0];
-                    let last_vertex = part[part.length - 1]
-                    if (first_vertex[0] !== last_vertex[0] || first_vertex[1] !== last_vertex[1]) {
-                        is_polygon_array = false;
-                    }
-                });
-                return is_polygon_array;
-            }
-        } else {
-            return false;
-        }
-    },
-    
-    fetch_json,
-    
-    fetch_jsons,
-
-    get_bounding_box,
-
-    // function to convert two points into a 
-    // representation of a line
-    get_line_from_points(start_point, end_point) {
-
-        // get a, b, and c from line equation ax + by = c
-        let x1 = start_point[0],
-            x2 = end_point[0],
-            y1 = start_point[1],
-            y2 = end_point[1];
-        let a = y2 - y1;
-        let b = x1 - x2;
-        let c = a * x1 + b * y1
-
-        // return just a b and c since that is all we need 
-        // to compute the intersection
-        return { a, b, c };
-    }, 
-
-    // function to get the point at which two lines intersect
-    // the input uses the line representations from the 
-    // get_line_from_points function
-    get_intersection_of_two_lines(line_1, line_2) {
-
-        // calculate the determinant, ad - cb in a square matrix |a b|
-        let det = line_1.a * line_2.b - line_2.a * line_1.b; /*  |c d| */
-
-        if (det) { // this makes sure the lines aren't parallel, if they are, det will equal 0
-            let x = (line_2.b * line_1.c - line_1.b * line_2.c) / det;
-            let y = (line_1.a * line_2.c - line_2.a * line_1.c) / det;
-            return { x, y };
-        }
-    },
-
-    get_slope_of_line(line) {
-        // assuming ax + by = c
-        // http://www.purplemath.com/modules/solvelit2.htm
-        return -1 * line.a / line.b;
-    },
-
-    get_slope_of_line_segment(line_segment) {
-        let [ [x1, y1], [x2, y2] ] = line_segment;
-        // make sure slope goes from left most to right most, so order of points doesn't matter
-        if (x2 > x1) {
-            return y2 - y1 / x2 - x1;
-        } else {
-            return y1 - y2 / x1 - x2;
-        }
-    },
-    
-    cluster,
-    
-    cluster_line_segments,
-    
-    sum(values) {
-        return values.reduce((a, b) => a + b);
+  /**
+   * This function takes in an array with an even number of elements and returns an array that couples every two consecutive elements;
+   * @name couple
+   * @param {Object} array of anything
+   * @returns {Object} array of consecutive pairs
+   * @example
+   * let items = [0, 1, 18, 77, 99, 103];
+   * let unflattened = utils.couple(items);
+   * // unflattened
+   * // [ [0, 1], [18, 77], [99, 103] ]
+  */
+  couple(array) {
+    let couples = [];
+    let length_of_array = array.length;
+    for (let i = 0; i < length_of_array; i+=2) {
+      couples.push([ array[i], array[i+1] ]);
     }
+    return couples;
+  },
+
+  force_within(n, min, max) {
+    if (n < min) n = min;
+    else if (n > max) n = max;
+    return n;
+  },
+
+  run_on_table_of_values,
+
+
+  /**
+   * This function categorizes an intersection
+   * @name categorize_intersection
+   * @param {Object} edges
+  */
+  categorize_intersection(segments) {
+    try {
+
+
+      let through, end, xmin, xmax;
+
+      let n = segments.length;
+
+      let first = segments[0];
+
+      if (n === 1) {
+        through = true;
+        xmin = first.xmin;
+        xmax = first.xmax;
+      } else /* n > 1 */ {
+        let last = segments[n - 1];
+        through = first.direction === last.direction;
+        xmin = Math.min(first.xmin, last.xmin);
+        xmax = Math.max(first.xmax, last.xmax);
+      }
+
+      if (xmin === undefined || xmax === undefined || through === undefined || isNaN(xmin) || isNaN(xmax)) {
+        console.error("segments:", segments);
+        throw Error("categorize_intersection failed with xmin", xmin, "and xmax", xmax);
+      }
+
+      return { xmin, xmax, through };
+
+    } catch (error) {
+
+      console.error("[categorize_intersection] segments:", segments);
+      console.error("[categorize_intersection]", error);
+      throw error;
+    }
+
+  },
+
+  convert_to_geojson_if_necessary(input, debug=false) {
+    if (this.is_esri_json(input, debug)) {
+      return this.toGeoJSON(input, debug);
+    } else {
+      return input;
+    }
+  },
+
+  count_values_in_table(table, no_data_value) {
+    let counts = {};
+    run_on_table_of_values(table, no_data_value, value => {
+      if (value in counts) counts[value]++;
+      else counts[value] = 1;
+    });
+    return counts;
+  },
+
+  convert_crs_bbox_to_image_bbox(georaster, crs_bbox) {
+
+    let crs_xmin, crs_ymin, crs_xmax, crs_ymax;
+    if (typeof crs_bbox.xmin !== "undefined") {
+      crs_xmin = crs_bbox.xmin;
+      crs_ymin = crs_bbox.ymin;
+      crs_xmax = crs_bbox.xmax;
+      crs_ymax = crs_bbox.ymax;
+    } else if (Array.isArray(crs_bbox) && crs_bbox.length === 4) {
+      // pull out bounding box values
+      crs_xmin = crs_bbox[0];
+      crs_ymin = crs_bbox[1];
+      crs_xmax = crs_bbox[2];
+      crs_ymax = crs_bbox[3];
+    }
+
+    // map bounding box values to image coordinate space
+    /* y_min uses lat_max while y_max uses lat_min because the image coordinate
+    system is inverted along the y axis relative to the lat/long (geographic)
+    coordinate system */
+    return {
+      xmin: Math.floor((crs_xmin - georaster.xmin) / georaster.pixelWidth),
+      ymin: Math.floor((georaster.ymax - crs_ymax) / georaster.pixelHeight),
+      xmax: Math.ceil((crs_xmax - georaster.xmin) / georaster.pixelWidth),
+      ymax: Math.ceil((georaster.ymax - crs_ymin) / georaster.pixelHeight)
+    };
+  },
+
+  get_geojson_coors(geojson, debug=false) {
+    if (debug) console.log("[get_geojson_coors] starting with", geojson);
+    let result;
+    if (geojson.features) { // for feature collections
+
+      // make sure that if any polygons are overlapping, we get the union of them
+      geojson = combine(geojson);
+
+      // turf adds extra arrays when running combine, so we need to remove them
+      // as we return the coordinates
+      result = geojson.features[0].geometry.coordinates
+        .map(coors => coors[0]);
+    } else if (geojson.geometry) { // for individual feature
+      if (debug) console.log("[get_geojson_coors] hits geojson.geometry");
+      result = geojson.geometry.coordinates;
+    } else if (geojson.coordinates) { // for just the geometry
+      result = geojson.coordinates;
+    }
+    if (debug) console.log("[get_geojson_coors] returning", JSON.stringify(result).substring(0, 100) + "...");
+    return result;
+  },
+
+  is_bbox(geometry) {
+
+    if (geometry === undefined || geometry === null) {
+      return false;
+    }
+
+    // check if we are using the gio format and return true right away if so
+    if (geometry.xmin !== undefined && geometry.xmax !== undefined && geometry.ymax !== undefined && geometry.ymin !== undefined) {
+      return true;
+    }
+
+    if ((Array.isArray(geometry) && geometry.length === 4)) { // array
+      return true;
+    }
+
+    // convert possible inputs to a list of coordinates
+    let coors;
+    if (typeof geometry === 'string') { // stringified geojson
+      let geojson = JSON.parse(geometry);
+      let geojson_coors = this.get_geojson_coors(geojson);
+      if (geojson_coors.length === 1 && geojson_coors[0].length === 5) {
+        coors = geojson_coors[0];
+      }
+    } else if (typeof geometry === 'object') { // geojson
+      let geojson_coors = this.get_geojson_coors(geometry);
+      if (geojson_coors) coors = geojson_coors[0];
+    } else {
+      return false;
+    }
+
+    // check to make sure coordinates make up a bounding box
+    if (coors && coors.length === 5 && _.isEqual(coors[0], coors[4])) {
+      let lngs = coors.map(coor => coor[0]);
+      let lats = coors.map(coor => coor[1]);
+      if (lngs[0] === lngs[3] && lats[0] === lats[1] && lngs[1] === lngs[2]) {
+        return true;
+      }
+    }
+    return false;
+  },
+
+  get_depth(geometry) {
+    let depth = 0;
+    let part = geometry;
+    while (Array.isArray(part)) {
+      depth++;
+      part = part[0];
+    }
+    return depth;
+  },
+
+  /**
+   * This function takes in an array of number pairs and combines where there's overlap
+   * @name
+   * @param {Object} array of anything
+   * @returns {Object} array of index ranges
+   * @example
+   * let ranges = [ [0, 10], [10, 10], [20, 30], [30, 40] ];
+   * let merged_ranges = utils.merge_ranges(ranges);
+   * // merged_ranges
+   * // [ [0, 10], [20, 40] ]
+  */
+  merge_ranges(ranges) {
+    let number_of_ranges = ranges.length;
+    if (number_of_ranges > 0) {
+      let first_range = ranges[0];
+      let previous_end = first_range[1];
+      let previous_start = first_range[0];
+      let result = [first_range];
+      for (let i = 1; i < number_of_ranges; i++) {
+        let temp_range = ranges[i];
+        let [start, end] = temp_range;
+        if (start <= previous_end) {
+          result[result.length - 1][1] = end;
+        } else {
+          result.push(temp_range);
+        }
+        previous_end = end;
+        previous_start = start;
+       }
+       return result;
+    }
+  },
+
+  is_esri_json(input, debug=false) {
+    if (debug) console.log("starting is_esri_json with", input);
+    let input_type = typeof input;
+    let obj = input_type === "string" ? JSON.parse(input) : input_type === "object" ? input : null;
+    let geometry = obj.geometry ? obj.geometry : obj;
+    if (geometry) {
+      if (geometry.rings || (geometry.x && geometry.y)) {
+        try {
+          if(ArcGIS.parse(obj)) {
+            return true;
+          } else {
+            return false;
+          }
+        } catch (error) {
+          console.error(error);
+          return false;
+        }
+      } else {
+        return false;
+      }
+    } else {
+      return false;
+    }
+  },
+
+  toGeoJSON(input, debug=false) {
+    if (debug) console.log("[toGeoJSON] starting with", input);
+    let parsed = ArcGIS.toGeoJSON(input);
+    if (debug) console.log("[toGeoJSON] parsed:", parsed);
+    return Array.isArray(parsed) ? parsed[0] : parsed;
+  },
+
+  is_polygon(geometry, debug=false) {
+
+    // convert to a geometry
+    let coors;
+    if (Array.isArray(geometry)) {
+      coors = geometry;
+    } else if (typeof geometry === 'string') {
+      let parsed = JSON.parse(geometry);
+      let geojson = this.convert_to_geojson_if_necessary(parsed, debug);
+      coors = this.get_geojson_coors(geojson, debug);
+    } else if (typeof geometry === 'object') {
+      let geojson = this.convert_to_geojson_if_necessary(geometry, debug);
+      coors = this.get_geojson_coors(geojson, debug);
+    }
+
+    if (coors) {
+
+      // iterate through each geometry and make sure first and
+      // last point are the same
+
+      let depth = this.get_depth(coors);
+      if (debug) console.log("depth:", depth);
+      if (depth === 4) {
+        return coors.map(() => this.is_polygon).every(Boolean);
+      } else if (depth === 3) {
+        let is_polygon_array = true;
+        coors.forEach(part => {
+          let first_vertex = part[0];
+          let last_vertex = part[part.length - 1]
+          if (first_vertex[0] !== last_vertex[0] || first_vertex[1] !== last_vertex[1]) {
+            is_polygon_array = false;
+          }
+        });
+        return is_polygon_array;
+      }
+    } else {
+      return false;
+    }
+  },
+
+  fetch_json,
+
+  fetch_jsons,
+
+  get_bounding_box,
+
+  // function to convert two points into a
+  // representation of a line
+  get_line_from_points(start_point, end_point) {
+
+    // get a, b, and c from line equation ax + by = c
+    let x1 = start_point[0],
+      x2 = end_point[0],
+      y1 = start_point[1],
+      y2 = end_point[1];
+    let a = y2 - y1;
+    let b = x1 - x2;
+    let c = a * x1 + b * y1
+
+    // return just a b and c since that is all we need
+    // to compute the intersection
+    return { a, b, c };
+  },
+
+  // function to get the point at which two lines intersect
+  // the input uses the line representations from the
+  // get_line_from_points function
+  get_intersection_of_two_lines(line_1, line_2) {
+
+    // calculate the determinant, ad - cb in a square matrix |a b|
+    let det = line_1.a * line_2.b - line_2.a * line_1.b; /*  |c d| */
+
+    if (det) { // this makes sure the lines aren't parallel, if they are, det will equal 0
+      let x = (line_2.b * line_1.c - line_1.b * line_2.c) / det;
+      let y = (line_1.a * line_2.c - line_2.a * line_1.c) / det;
+      return { x, y };
+    }
+  },
+
+  get_slope_of_line(line) {
+    // assuming ax + by = c
+    // http://www.purplemath.com/modules/solvelit2.htm
+    return -1 * line.a / line.b;
+  },
+
+  get_slope_of_line_segment(line_segment) {
+    let [ [x1, y1], [x2, y2] ] = line_segment;
+    // make sure slope goes from left most to right most, so order of points doesn't matter
+    if (x2 > x1) {
+      return y2 - y1 / x2 - x1;
+    } else {
+      return y1 - y2 / x1 - x2;
+    }
+  },
+
+  cluster,
+
+  cluster_line_segments,
+
+  sum(values) {
+    return values.reduce((a, b) => a + b);
+  }
 }

--- a/packages/utils/utils.js
+++ b/packages/utils/utils.js
@@ -283,7 +283,7 @@ module.exports = {
       return false;
     }
 
-    // check if we are using the gio format and return true right away if so
+    // check if we are using the geoblaze format and return true right away if so
     if (geometry.xmin !== undefined && geometry.xmax !== undefined && geometry.ymax !== undefined && geometry.ymin !== undefined) {
       return true;
     }

--- a/web/index.html
+++ b/web/index.html
@@ -1,66 +1,66 @@
 <!DOCTYPE html>
 <html>
-    <head>
+  <head>
 
-        <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <title>Gio Testing Page</title>
-        <meta name="description" content="This is just a page for testing stuff in the browser">
-        <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css"/>
+    <title>Gio Testing Page</title>
+    <meta name="description" content="This is just a page for testing stuff in the browser">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css"/>
 
-        <script src='https://cdnjs.cloudflare.com/ajax/libs/js-polyfills/0.1.33/polyfill.min.js'></script>
-        <script src='js/proj4.js'></script>
-        <script src='js/proj4-src.js'></script>
-        <script>
-            function load_script(url) {
-                return new Promise((resolve, reject) => {
-                    var script = document.createElement("script");
-                    script.onload = resolve;
-                    script.src = url;
-                    document.body.appendChild(script);
-                });
-            }
-            function load_style(url) {
-                return new Promise((resolve, reject) => {
-                    var link = document.createElement("link");
-                    link.setAttribute("rel", "stylesheet");
-                    link.setAttribute("type", "text/css");
-                    link.setAttribute("href", url);
-                    link.onload = resolve;
-                    document.head.appendChild(link);
-                });
-            }
-        </script>
+    <script src='https://cdnjs.cloudflare.com/ajax/libs/js-polyfills/0.1.33/polyfill.min.js'></script>
+    <script src='js/proj4.js'></script>
+    <script src='js/proj4-src.js'></script>
+    <script>
+      function load_script(url) {
+        return new Promise((resolve, reject) => {
+          var script = document.createElement("script");
+          script.onload = resolve;
+          script.src = url;
+          document.body.appendChild(script);
+        });
+      }
+      function load_style(url) {
+        return new Promise((resolve, reject) => {
+          var link = document.createElement("link");
+          link.setAttribute("rel", "stylesheet");
+          link.setAttribute("type", "text/css");
+          link.setAttribute("href", url);
+          link.onload = resolve;
+          document.head.appendChild(link);
+        });
+      }
+    </script>
 
-        <!-- for vectorfield -->
-        <script src="//cdnjs.cloudflare.com/ajax/libs/chroma-js/1.3.0/chroma.min.js"></script>
-        <script src="//d3js.org/d3.v4.min.js"></script>
+    <!-- for vectorfield -->
+    <script src="//cdnjs.cloudflare.com/ajax/libs/chroma-js/1.3.0/chroma.min.js"></script>
+    <script src="//d3js.org/d3.v4.min.js"></script>
 
-        <script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet.js"></script>
-        <script src="https://unpkg.com/geotiff@0.4.1/dist/geotiff.browserify.min.js"></script>
-        <script src="https://unpkg.com/leaflet-providers@1.1.17/leaflet-providers.js"></script>
-        <script src="https://ihcantabria.github.io/Leaflet.CanvasLayer.Field/dist/leaflet.canvaslayer.field.js"></script>
-        <link href="css/style.css" rel="stylesheet">
+    <script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet.js"></script>
+    <script src="https://unpkg.com/geotiff@0.4.1/dist/geotiff.browserify.min.js"></script>
+    <script src="https://unpkg.com/leaflet-providers@1.1.17/leaflet-providers.js"></script>
+    <script src="https://ihcantabria.github.io/Leaflet.CanvasLayer.Field/dist/leaflet.canvaslayer.field.js"></script>
+    <link href="css/style.css" rel="stylesheet">
 
 
-        <!-- Bootstrap -->
-        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
-        <script src="https://code.jquery.com/jquery-3.1.1.slim.min.js" integrity="sha384-A7FZj7v+d/sdmMqp/nOQwliLvUsJfDHW+k9Omg/a/EheAdgtzNs3hpfag6Ed950n" crossorigin="anonymous"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js" integrity="sha384-DztdAPBWPRXSA/3eYEEUWrWCy7G5KFbe8fFjk5JAIxUYHKkDx6Qin1DkWx51bBrb" crossorigin="anonymous"></script>
-        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js" integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn" crossorigin="anonymous"></script>
+    <!-- Bootstrap -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
+    <script src="https://code.jquery.com/jquery-3.1.1.slim.min.js" integrity="sha384-A7FZj7v+d/sdmMqp/nOQwliLvUsJfDHW+k9Omg/a/EheAdgtzNs3hpfag6Ed950n" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js" integrity="sha384-DztdAPBWPRXSA/3eYEEUWrWCy7G5KFbe8fFjk5JAIxUYHKkDx6Qin1DkWx51bBrb" crossorigin="anonymous"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js" integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn" crossorigin="anonymous"></script>
 
-    </head>
-    <body>
-        <script>
-            let url = 'http://localhost:3000/data/test.tiff';
-            let tiff, image;
+  </head>
+  <body>
+    <script>
+      let url = 'http://localhost:3000/data/test.tiff';
+      let tiff, image;
 
-            fetch(url)
-                .then(r => r.arrayBuffer())
-                .then(buffer => tiff = GeoTIFF.parse(buffer))
-                .then(tiff => image = tiff.getImage());
-        </script>
-    </body>
+      fetch(url)
+        .then(r => r.arrayBuffer())
+        .then(buffer => tiff = GeoTIFF.parse(buffer))
+        .then(tiff => image = tiff.getImage());
+    </script>
+  </body>
 
 
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <title>Gio Testing Page</title>
+    <title>Geoblaze Testing Page</title>
     <meta name="description" content="This is just a page for testing stuff in the browser">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css"/>
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,25 +2,25 @@ var path = require('path');
 var webpack = require('webpack');
 
 module.exports = {
-    entry: './index.js',
-    output: {
-        path: path.resolve(__dirname, 'build'),
-        filename: 'geoblaze.js',
-        library: 'geoblaze',
-        libraryTarget: 'umd',
-        umdNamedDefine: true
-    },
-    module: {
-        loaders: [
-            {
-                test: /\.js$/,
-                loader: 'babel-loader',
-                exclude: /node_modules/,
-            }
-        ]
-    },
-    stats: {
-        colors: true
-    },
-    devtool: 'source-map'
+  entry: './index.js',
+  output: {
+    path: path.resolve(__dirname, 'build'),
+    filename: 'geoblaze.js',
+    library: 'geoblaze',
+    libraryTarget: 'umd',
+    umdNamedDefine: true
+  },
+  module: {
+    loaders: [
+      {
+        test: /\.js$/,
+        loader: 'babel-loader',
+        exclude: /node_modules/,
+      }
+    ]
+  },
+  stats: {
+    colors: true
+  },
+  devtool: 'source-map'
 };


### PR DESCRIPTION
## What
This PR adds error handling to `geoblaze.load` so that users can see an error bubble up when an incorrect url is used or it fails to parse the input.

## Why
This is necessary for proper error handling on the geotiff.io side. Plus it makes for a better UX.