### PR TITLE
added improved error handling for bad urls in load

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,16 @@
+module.exports = {
+  ERROR_LOAD_FILE_OUTSIDE_BROWSER: `
+    Direct raster loading is currently not supported outside of the browser
+    due to dependency limitations. Please use either a url or run the code
+    in the browser.
+  `,
+  ERROR_BAD_URL: `
+    Geoblaze could not load the file. This is usually because the url is incorrect
+    or the website's security prevents cross domain requests. Try again or download
+    the file and load it manually.
+  `,
+  ERROR_PARSING_GEOTIFF: `
+    Geoblaze had a problem parsing this file. Please make sure that you are sending a proper
+    GeoTIFF file and try again.
+  `
+};

--- a/packages/convert-geometry/test.js
+++ b/packages/convert-geometry/test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 let expect = require('chai').expect;
-let gio_convert_geometry = require('./convert-geometry');
+let geoblaze_convert_geometry = require('./convert-geometry');
 
 let array_point = [102, 0.5];
 
@@ -51,13 +51,13 @@ let geojson_polygon_1 = JSON.parse(geojson_polygon_str_1);
 let geojson_polygon_2 = JSON.parse(geojson_polygon_str_2);
 
 let test_point_load = feature => {
-  let point = gio_convert_geometry('point', feature);
+  let point = geoblaze_convert_geometry('point', feature);
   expect(point[0]).to.equal(102);
   expect(point[1]).to.equal(0.5);
 }
 
 let test_bbox_load = feature => {
-  let bbox = gio_convert_geometry('bbox', feature);
+  let bbox = geoblaze_convert_geometry('bbox', feature);
   expect(bbox.xmin).to.equal(100);
   expect(bbox.ymin).to.equal(0);
   expect(bbox.xmax).to.equal(101);
@@ -65,7 +65,7 @@ let test_bbox_load = feature => {
 }
 
 let test_polygon_load = feature => {
-  let polygon = gio_convert_geometry('polygon', feature);
+  let polygon = geoblaze_convert_geometry('polygon', feature);
 
 }
 

--- a/packages/get/get.js
+++ b/packages/get/get.js
@@ -63,7 +63,7 @@ module.exports = (georaster, geom, flat) => {
 
   } else {
 
-    throw 'Geometry is not a bounding box - please make sure to send a bounding box when using gio-get';
+    throw 'Geometry is not a bounding box - please make sure to send a bounding box when using geoblaze.get';
 
   }
 

--- a/packages/histogram/test.js
+++ b/packages/histogram/test.js
@@ -79,7 +79,7 @@ let polygon_geojson = `{
 }`
 
 let test = () => {
-  describe('Gio Histogram Feature', function() {
+  describe('Geoblaze Histogram Feature', function() {
     describe('Get Histogram (Ratio, Quantile) from Bounding Box', function() {
       this.timeout(1000000);
       it('Got Correct Value', () => {

--- a/packages/identify/test.js
+++ b/packages/identify/test.js
@@ -10,7 +10,7 @@ let point = [80.63, 7.42];
 let expected_value = 350.7;
 
 let test = () => (
-  describe('Gio Identify Feature', function() {
+  describe('Geoblaze Identify Feature', function() {
     describe('Identify Point in Raster', function() {
       this.timeout(1000000);
       it('Identified Point Correctly', () => {

--- a/packages/load/load.js
+++ b/packages/load/load.js
@@ -1,10 +1,14 @@
 'use strict';
 
-let parse_georaster = require("georaster");
+const parse_georaster = require("georaster");
 
-let in_browser = typeof window === 'object';
+const in_browser = typeof window === 'object';
 var fetch = in_browser ? window.fetch : require('node-fetch');
 var URL = in_browser ? window.URL : require("url").parse;
+
+const error_load_file_outside_browser = require('../../constants').ERROR_LOAD_FILE_OUTSIDE_BROSWER;
+const error_bad_url = require('../../constants').ERROR_BAD_URL;
+const error_parsing_geotiff = require('../../constants').ERROR_PARSING_GEOTIFF;
 
 let cache = require('../cache/cache');
 
@@ -12,41 +16,35 @@ module.exports = (url_or_file) => (
 
   new Promise((resolve, reject) => {
     if (!in_browser && typeof url_or_file === 'object') {
-      throw `Direct raster loading is currently not supported outside of the browser
-        due to dependency limitations. Please use either a url or run the code
-        in the browser.`
+      reject(new Error(error_load_file_outside_browser));
     }
 
-    let url = typeof url_or_file === 'object' ? URL.createObjectURL(url_or_file) : url_or_file;
-    //console.log("url:", url);
+    const url = typeof url_or_file === 'object' ? URL.createObjectURL(url_or_file) : url_or_file;
 
     if (cache[url]) {
       resolve(cache[url]);
     } else {
-      fetch(url).then(
-        response => in_browser ? response.arrayBuffer() : response.buffer() ,
-        error => {
-          let domain = new URL(url).host;
-          let error_message = `Gio could not get the file from ${domain}.
-            This is often because a website's security prevents cross domain requests.
-            Download the file and load it manually.`;
-          console.error(error_message);
-          reject(error_message);
-        }
-      ).then(b => {
-        //console.log("b:", b);
-        if (b) {
-          let array_buffer;
-          if (in_browser) {
-            array_buffer = b;
-          } else {
-            array_buffer = b.buffer.slice(b.byteOffset, b.byteOffset + b.byteLength);
+      fetch(url).then(response => {
+        if (response.ok) return in_browser ? response.arrayBuffer() : response.buffer()
+
+        const domain = new URL(url).host;
+        reject(new Error(error_bad_url));
+      }).then(b => {
+        try {
+          if (b) {
+            let array_buffer;
+            if (in_browser) {
+              array_buffer = b;
+            } else {
+              array_buffer = b.buffer.slice(b.byteOffset, b.byteOffset + b.byteLength);
+            }
+            parse_georaster(array_buffer).then(georaster => {
+              cache[url] = georaster;
+              resolve(georaster);
+            });
           }
-          parse_georaster(array_buffer).then(georaster => {
-            cache[url] = georaster;
-            //console.log("resolving:", georaster);
-            resolve(georaster);
-          });
+        } catch (e) {
+          reject(new Error(error_parsing_geotiff));
         }
       });
     }

--- a/packages/load/test.js
+++ b/packages/load/test.js
@@ -1,21 +1,24 @@
 'use strict';
 
-let expect = require('chai').expect;
+const expect = require('chai').expect;
 
-let fetch = require('node-fetch');
+const fetch = require('node-fetch');
 
-let load = require('./load');
+const load = require('./load');
 
-let path = 'http://localhost:3000/data/test.tiff';
+const path = 'http://localhost:3000/data/test.tiff';
+const incorrect_path = 'http://localhost:3000/data/this-is-not-a-real-dataset.tiff';
 
-let properties = [
+const error_bad_url = require('../../constants').ERROR_BAD_URL;
+
+const properties = [
   'projection',
   'xmin',
   'values'
 ];
 
-let test = () => (
-  describe('Gio Load Feature', function() {
+const test = () => (
+  describe('Geoblaze Load Feature', function() {
     describe('Load from URL', function() {
       this.timeout(1000000);
       it('Loaded tiff file', () => {
@@ -23,6 +26,15 @@ let test = () => (
           properties.forEach(property => {
             expect(georaster).to.have.property(property);
           });
+        });
+      });
+    });
+
+    describe('Error from invalid URL', function() {
+      this.timeout(1000000);
+      it('Loaded tiff file', () => {
+        return load(incorrect_path).then(null, error => {
+          expect(error.message).to.equal(error_bad_url);
         });
       });
     });

--- a/packages/max/test.js
+++ b/packages/max/test.js
@@ -18,7 +18,7 @@ let polygon = [[
 let expected_polygon_value = 7807.40;
 
 let test = () => {
-  describe('Gio Max Feature', function() {
+  describe('Geoblaze Max Feature', function() {
     describe('Get Max from Bounding Box', function() {
       this.timeout(1000000);
       it('Got Correct Value', () => {

--- a/packages/mean/test.js
+++ b/packages/mean/test.js
@@ -40,7 +40,7 @@ let polygon_geojson = `{
 let expected_polygon_geojson_value = 1826.74 ;
 
 let test = () => {
-  describe('Gio Mean Feature', function() {
+  describe('Geoblaze Mean Feature', function() {
     describe('Get Mean from Bounding Box', function() {
       this.timeout(1000000);
       it('Got Correct Value', () => {

--- a/packages/median/test.js
+++ b/packages/median/test.js
@@ -35,7 +35,7 @@ let polygon = [[
 let expected_polygon_value = 2750.5;
 
 let test = () => {
-  describe('Gio Median Feature', function() {
+  describe('Geoblaze Median Feature', function() {
     describe('Get Median from Bounding Box', function() {
       this.timeout(1000000);
       it('Got Correct Value', () => {

--- a/packages/min/test.js
+++ b/packages/min/test.js
@@ -17,7 +17,7 @@ let polygon = [[
 let expected_polygon_value = 0;
 
 let test = () => {
-  describe('Gio Min Feature', function() {
+  describe('Geoblaze Min Feature', function() {
     describe('Get Min from Bounding Box', function() {
       this.timeout(1000000);
       it('Got Correct Value', () => {

--- a/packages/mode/test.js
+++ b/packages/mode/test.js
@@ -18,7 +18,7 @@ let polygon = [[
 let expected_polygon_value = 0;
 
 let test = () => {
-  describe('Gio Mode Feature', function() {
+  describe('Geoblaze Mode Feature', function() {
     describe('Get Mode from Bounding Box', function() {
       this.timeout(1000000);
       it('Got Correct Value', () => {

--- a/packages/sum/test.js
+++ b/packages/sum/test.js
@@ -218,7 +218,7 @@ let polygon_geojson_collection = `{
 let expected_polygon_geojson_collection_value = expected_polygon_geojson_value_1 + expected_polygon_geojson_value_2;
 
 let test = () => {
-  describe('Gio Sum Feature', function() {
+  describe('Geoblaze Sum Feature', function() {
     describe('Get Sum', function() {
       this.timeout(1000000);
       it('Got Correct Value', () => {

--- a/packages/utils/utils.js
+++ b/packages/utils/utils.js
@@ -283,7 +283,7 @@ module.exports = {
       return false;
     }
 
-    // check if we are using the gio format and return true right away if so
+    // check if we are using the geoblaze format and return true right away if so
     if (geometry.xmin !== undefined && geometry.xmax !== undefined && geometry.ymax !== undefined && geometry.ymin !== undefined) {
       return true;
     }

--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <title>Gio Testing Page</title>
+    <title>Geoblaze Testing Page</title>
     <meta name="description" content="This is just a page for testing stuff in the browser">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css"/>
 


### PR DESCRIPTION
## What
This PR adds error handling to `geoblaze.load` so that users can see an error bubble up when an incorrect url is used or it fails to parse the input.

## Why
This is necessary for proper error handling on the geotiff.io side. Plus it makes for a better UX.