### PR TITLE
handle not-a-number values in band arithmetic and raster calculator

### DIFF
--- a/src/band-arithmetic/band-arithmetic.module.js
+++ b/src/band-arithmetic/band-arithmetic.module.js
@@ -101,7 +101,7 @@ const bandArithmetic = (georaster, arithmetic) => {
             row.push(noDataValue);
           } else {
             const value = arithmeticFunction(...bandValues);
-            if (value === Infinity || value === -Infinity) {
+            if (value === Infinity || value === -Infinity || isNaN(value)) {
               row.push(noDataValue);
             } else {
               row.push(value);

--- a/src/band-arithmetic/band-arithmetic.test.js
+++ b/src/band-arithmetic/band-arithmetic.test.js
@@ -22,6 +22,7 @@ const getExpectedValue5 = (a, b, c) => 2 * (b + a * c) - 100;
 const calculation6 = '(a + b) / c';
 const getExpectedValue6 = (a, b, c) => (a + b) / c;
 
+const calculation7 = '(a - a) / (b - b)';
 
 function expectNoInfinityValues (georaster) {
   georaster.values.forEach(band => {
@@ -33,6 +34,15 @@ function expectNoInfinityValues (georaster) {
   });
 }
 
+function expectNoNaNValues (georaster) {
+  georaster.values.forEach(band => {
+    band.forEach(row => {
+      row.forEach(pixel => {
+        expect(pixel).to.not.equal(NaN);
+      });
+    });
+  });
+}
 // left the time measuring code commented out in the tests to make
 // it easier to return and further optimize the code
 
@@ -126,7 +136,7 @@ describe('Geoblaze Band Arithmetic Feature', () => {
       });
     });
   });
-  
+
   describe('Run Calculation 6', function () {
     this.timeout(1000000);
     it('Got Correct Value', () => {
@@ -141,5 +151,16 @@ describe('Geoblaze Band Arithmetic Feature', () => {
         });
       });
     });
-  });  
+  });
+
+  describe('Run Calculation 7', function () {
+    this.timeout(1000000);
+    it('Got Correct Value', () => {
+      return load(url).then(georaster => {
+        return bandArithmetic(georaster, calculation7).then(computedGeoraster => {
+          expectNoNaNValues(computedGeoraster);
+        });
+      });
+    });
+  });
 });

--- a/src/raster-calculator/raster-calculator.module.js
+++ b/src/raster-calculator/raster-calculator.module.js
@@ -50,7 +50,7 @@ const rasterCalculator = (georaster, func) => {
             row.push(noDataValue);
           } else {
             const value = func(...bandValues);
-            if (value === Infinity || value === -Infinity) {
+            if (value === Infinity || value === -Infinity || isNaN(value)) {
               row.push(noDataValue);
             } else {
               row.push(value);

--- a/src/raster-calculator/raster-calculator.test.js
+++ b/src/raster-calculator/raster-calculator.test.js
@@ -25,11 +25,23 @@ const calculation7 = (a, b, c) => {
   }
 };
 
+const calculation8 = () => NaN;
+
 function expectNoInfinityValues (georaster) {
   georaster.values.forEach(band => {
     band.forEach(row => {
       row.forEach(pixel => {
         expect(pixel).to.not.equal(Infinity);
+      });
+    });
+  });
+}
+
+function expectNoNaNValues (georaster) {
+  georaster.values.forEach(band => {
+    band.forEach(row => {
+      row.forEach(pixel => {
+        expect(pixel).to.not.equal(NaN);
       });
     });
   });
@@ -127,7 +139,7 @@ describe('Geoblaze Raster Calculator Feature', () => {
       });
     });
   });
-  
+
   describe('Run Calculation 6', function () {
     this.timeout(1000000);
     it('Got Correct Value', () => {
@@ -146,7 +158,7 @@ describe('Geoblaze Raster Calculator Feature', () => {
       });
     });
   });
-  
+
   describe('Run Calculation 7', function () {
     this.timeout(1000000);
     it('Got Correct Value', () => {
@@ -161,5 +173,16 @@ describe('Geoblaze Raster Calculator Feature', () => {
         });
       });
     });
-  });    
+  });
+
+  describe('Run Calculation 8', function () {
+    this.timeout(1000000);
+    it('Got Correct Value', () => {
+      return load(url).then(georaster => {
+        return rasterCalculator(georaster, calculation8).then(computedGeoraster => {
+          expectNoNaNValues(computedGeoraster);
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Type of PR
- [x] Bug Fix
- [ ] Feature

## What is the Goal of the PR?
Fix a bug where NaN values arise in band arithmetic or raster calculator. This will happen if you do something like 0 / 0. Similar to `Infinity`, this PR will filter out `NaN` values and replace them with the `noDataValue`.

## What is the Motivation for the PR?
Fix dem bugs

## What Tests are Included?
Added a test which deliberately sets `NaN` results and checks to see if the computed raster has `NaN` values.
