### PR TITLE
Directly specify which bundle to use in browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "version": "0.2.6",
   "description": "Blazing Fast JavaScript Raster Processing Engine",
   "main": "dist/geoblaze.node.min.js",
-  "browser": {
-    "./dist/geoblaze.web.min.js": "./dist/geoblaze.web.min.js"
-  },
+  "browser": "./dist/geoblaze.web.min.js",
   "unpkg": "./dist/geoblaze.web.min.js",
   "scripts": {
     "analyze": "webpack --config webpack.analyze.js",


### PR DESCRIPTION
## Type of PR
- [x] Bug Fix
- [ ] Feature

## What is the Goal of the PR?
Fix issues with not being able to load the latest version in Angular and other projects

## What is the Motivation for the PR?
We need this library in our application, version 0.2.2 works but we'd rather keep up to date with later versions. Trying to import the newest version throws errors similar to https://github.com/GeoTIFF/geoblaze/issues/165.
As far as my understanding about webpack and bundling goes (please note, I haven't used those tools directly a lot, so my understanding might be limited), the browser key can be directly set to the script to use. Setting an object is usually used when other modules are required which are not available in the browser, which you can then shim or just completely ignore.
(https://github.com/defunctzombie/package-browser-field-spec)

## What Tests are Included?
None