### PR TITLE
Add typescript definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "license": "MIT",
       "dependencies": {
         "@turf/combine": "^4.7.3",
+        "@types/geojson": "^7946.0.7",
         "georaster": "^1.0.3",
         "get-depth": "0.0.0",
         "mathjs": "^6.6.1",
@@ -1444,9 +1445,9 @@
       "integrity": "sha1-beLx6YkLj2S2aeS0fAmyCJMGOXc="
     },
     "node_modules/@types/geojson": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-1.0.6.tgz",
-      "integrity": "sha512-Xqg/lIZMrUd0VRmSRbCAewtwGZiAk3mEUDvV4op1tGl+LvyPcb/MIOSxTl9z+9+J+R4/vpjiCAT4xeKzH9ji1w=="
+      "version": "7946.0.7",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.7.tgz",
+      "integrity": "sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ=="
     },
     "node_modules/@types/glob": {
       "version": "7.1.3",
@@ -12094,6 +12095,11 @@
         "terraformer": "~1.0.4"
       }
     },
+    "node_modules/terraformer-arcgis-parser/node_modules/@types/geojson": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-1.0.6.tgz",
+      "integrity": "sha512-Xqg/lIZMrUd0VRmSRbCAewtwGZiAk3mEUDvV4op1tGl+LvyPcb/MIOSxTl9z+9+J+R4/vpjiCAT4xeKzH9ji1w=="
+    },
     "node_modules/terser": {
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
@@ -15643,9 +15649,9 @@
       "integrity": "sha1-beLx6YkLj2S2aeS0fAmyCJMGOXc="
     },
     "@types/geojson": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-1.0.6.tgz",
-      "integrity": "sha512-Xqg/lIZMrUd0VRmSRbCAewtwGZiAk3mEUDvV4op1tGl+LvyPcb/MIOSxTl9z+9+J+R4/vpjiCAT4xeKzH9ji1w=="
+      "version": "7946.0.7",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.7.tgz",
+      "integrity": "sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ=="
     },
     "@types/glob": {
       "version": "7.1.3",
@@ -24898,6 +24904,13 @@
       "requires": {
         "@types/geojson": "^1.0.0",
         "terraformer": "~1.0.4"
+      },
+      "dependencies": {
+        "@types/geojson": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-1.0.6.tgz",
+          "integrity": "sha512-Xqg/lIZMrUd0VRmSRbCAewtwGZiAk3mEUDvV4op1tGl+LvyPcb/MIOSxTl9z+9+J+R4/vpjiCAT4xeKzH9ji1w=="
+        }
       }
     },
     "terser": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/geoblaze.node.min.js",
   "browser": "./dist/geoblaze.web.min.js",
   "unpkg": "./dist/geoblaze.web.min.js",
+  "types": "src/index.d.ts",
   "scripts": {
     "analyze": "webpack --config webpack.analyze.js",
     "build": "npm run build:dev && npm run build:prod",
@@ -48,6 +49,7 @@
   "homepage": "https://github.com/GeoTIFF/geoblaze#readme",
   "dependencies": {
     "@turf/combine": "^4.7.3",
+    "@types/geojson": "^7946.0.7",
     "georaster": "^1.0.3",
     "get-depth": "0.0.0",
     "mathjs": "^6.6.1",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,92 @@
+import { Point, Polygon, Feature, BBox } from "geojson";
+
+export declare type GeoblazeBBox = {
+  xmin: number;
+  xmax: number;
+  ymin: number;
+  ymax: number;
+};
+
+export interface HistogramOptions {
+  scaleType: "nominal" | "ratio";
+  numClasses: number;
+  classType: "equal-interval" | "quantile";
+}
+
+export interface Histogram {
+  [binKey: string]: number[];
+}
+
+export class GeoRaster {
+  constructor(
+    data: object | string | Buffer | ArrayBuffer | number[][],
+    metadata: any,
+    debug: any
+  );
+}
+
+export type InputPolygon = number[][][] | Polygon | Feature<Polygon>;
+export type InputPoint = number[] | Point | Feature<Point>;
+export type InputBBox = BBox | GeoblazeBBox;
+
+export function bandArithmetic(
+  raster: GeoRaster,
+  arithmetic: any
+): Promise<GeoRaster>;
+
+export function get(
+  raster: GeoRaster,
+  geom: any,
+  flat: boolean
+): Promise<GeoRaster>;
+
+// Done
+export function histogram(
+  raster: GeoRaster,
+  geom: string | InputPolygon | null | undefined,
+  options: HistogramOptions
+): Histogram[];
+
+export function identify(
+  raster: GeoRaster,
+  geom?: string | InputPoint | null
+): number[];
+
+export function load(urlOrFile: object | string): Promise<GeoRaster>;
+
+export function max(
+  raster: GeoRaster,
+  geom: string | InputPolygon | null
+): Promise<GeoRaster>;
+
+export function mean(
+  raster: GeoRaster,
+  geom: string | InputPolygon | null
+): Promise<GeoRaster>;
+
+export function median(
+  raster: GeoRaster,
+  geom: string | InputPolygon | null
+): Promise<GeoRaster>;
+
+export function min(
+  raster: GeoRaster,
+  geom: string | InputPolygon | null
+): Promise<GeoRaster>;
+
+export function mode(
+  raster: GeoRaster,
+  geom: string | InputPolygon | null
+): Promise<GeoRaster>;
+
+export function rasterCalculator(
+  raster: GeoRaster,
+  operation: string
+): GeoRaster;
+
+export function sum(
+  raster: GeoRaster,
+  geom: string | InputPolygon | null,
+  test?: any,
+  debug?: boolean
+): Promise<Array<number>>;


### PR DESCRIPTION
## Type of PR
- [x] Feature

## What is the Goal of the PR?
Add Typescript type definitions for Typescript users.  Builds on [existing `geojson`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/geojson/index.d.ts) types in DefinitelyTyped

Checklist:

- [ ] Add build step to copy the declaration file into the `dist` folder for distribution.  Webpack may be the tool to do it.
- [ ] Switch `types` in package.json to point to dist/index.d.ts
- [ ] Review with fine toothed comb

