### PR TITLE
fix wrapGeom when geom.srs === georaster.projection

### DIFF
--- a/src/identify/identify.test.js
+++ b/src/identify/identify.test.js
@@ -61,3 +61,11 @@ test("(Modern) Identified Point Correctly from file", async ({ eq }) => {
   const values = await identify(url, { srs, geometry: geom });
   eq(values, [expectedValue]);
 });
+
+test("(Modern) Identified Same-SRS Point Correctly from file", async ({ eq }) => {
+  const georaster = await load(url);
+  const srs = georaster.projection;
+  const geom = await reprojectGeoJSON(point, { to: srs });
+  const values = identify(georaster, { srs, geometry: geom });
+  eq(values, [expectedValue]);
+});

--- a/src/wrap-geom.js
+++ b/src/wrap-geom.js
@@ -13,6 +13,8 @@ export default function wrapGeom(func) {
         } else {
           geom = reprojectGeoJSON(geometry, { from: srs, to: georaster.projection });
         }
+      } else {
+        geom = geom.geometry;
       }
     }
     return func(georaster, geom, ...rest);


### PR DESCRIPTION
## Type of PR
- [X] Bug Fix
- [ ] Feature

## What is the Goal of the PR?

Fix bug in wrapGeom.

## What is the Motivation for the PR?

wrapGeom passes input object rather than only geometry when srs matches georaster, causing wrapped function to raise "Invalid point object was used." or similar error.

## What Tests are Included?

New test for the bug that is fixed.
