### PR TITLE
added test case for New Zealand Land+EEZ intersecting habitat

### DIFF
--- a/data/create_expected_truth_data.py
+++ b/data/create_expected_truth_data.py
@@ -28,7 +28,9 @@ test_cases = [
   ["./antimeridian/right-edge.shp", "gfwfiji_6933_COG.tiff"],
   ["./antimeridian/right-edge.shp", "gfwfiji_6933_COG.tiff", { "boundless": False, "nodata": -9999 }],
   ["./antimeridian/split.shp", "gfwfiji_6933_COG_Binary.tif"],
-  ["./antimeridian/across.shp", "gfwfiji_6933_COG_Binary.tif"]
+  ["./antimeridian/across.shp", "gfwfiji_6933_COG_Binary.tif"],
+
+  ["./geojson-test-data/EEZ_Land_v3_202030_New_Zealand.geojson", "./geotiff-test-data/nz_habitat_anticross_4326_1deg.tif"]
 ]
 
 for i, (geom, raster, *opts) in enumerate(test_cases):

--- a/data/expected_data.txt
+++ b/data/expected_data.txt
@@ -143,6 +143,17 @@ case: 13
         sum: 29,211,252.0
 
 
+case: 14
+  vector: ./geojson-test-data/EEZ_Land_v3_202030_New_Zealand.geojson
+  raster: ./geotiff-test-data/nz_habitat_anticross_4326_1deg.tif
+  opts: []
+  result:
+        count: 454
+        min: 1.0
+        max: 71.0
+        sum: 4,512.0
+
+
 sum
 test.tiff
 108343045.40000004
@@ -168,6 +179,7 @@ Cyprus:  790,242.0625
 Jamaica:  2,332,581.75
 Lebanon:  5,554,060.0
 Macedonia:  2,239,499.25
+New Zealand:  0.0
 Nicaragua:  5,066,313.5
 Ukraine:  12,697,956.0
 Uruguay:  3,303,090.0

--- a/data/gadm/extract_countries.js
+++ b/data/gadm/extract_countries.js
@@ -12,6 +12,7 @@ const countries_to_extract = new Set([
   "Nicaragua",
   "Lebanon",
   "Macedonia",
+  "New Zealand",
   "Uruguay",
   "Ukraine"
 ]);

--- a/setup.sh
+++ b/setup.sh
@@ -10,6 +10,13 @@ bash setup.sh
 cd ..
 echo "---------- Finished Setting up GeoTIFF Data ----------"
 
+# setup test-data
+echo "---------- Setting up GeoJSON Test Data ----------"
+cd geojson-test-data
+bash setup.sh
+cd ..
+echo "---------- Finished Setting up GeoJSON Data ----------"
+
 # setup gadm
 echo "---------- Setting up GADM Data ----------"
 cd gadm


### PR DESCRIPTION
Add new test to double check calculations when polygon pre-split on anti-meridian and geotiff is global with data at each "end" of the world.